### PR TITLE
Adjust fiducial helper naming

### DIFF
--- a/include/rarexsec/FiducialVolume.h
+++ b/include/rarexsec/FiducialVolume.h
@@ -1,0 +1,47 @@
+#ifndef ANALYSIS_FIDUCIALVOLUME_H
+#define ANALYSIS_FIDUCIALVOLUME_H
+
+namespace analysis {
+
+namespace fiducial {
+
+inline constexpr float kMinX = 5.f;
+inline constexpr float kMaxX = 251.f;
+inline constexpr float kMinY = -110.f;
+inline constexpr float kMaxY = 110.f;
+inline constexpr float kMinZ = 20.f;
+inline constexpr float kMaxZ = 986.f;
+inline constexpr float kRecoGapMinZ = 675.f;
+inline constexpr float kRecoGapMaxZ = 775.f;
+
+namespace detail {
+
+template <typename T>
+inline bool is_within(const T &value, float low, float high) {
+  return value > low && value < high;
+}
+
+template <typename X, typename Y, typename Z>
+inline bool is_in_active_volume(const X &x, const Y &y, const Z &z) {
+  return is_within(x, kMinX, kMaxX) && is_within(y, kMinY, kMaxY) &&
+         is_within(z, kMinZ, kMaxZ);
+}
+
+} // namespace detail
+
+template <typename X, typename Y, typename Z>
+inline bool is_in_truth_volume(const X &x, const Y &y, const Z &z) {
+  return detail::is_in_active_volume(x, y, z);
+}
+
+template <typename X, typename Y, typename Z>
+inline bool is_in_reco_volume(const X &x, const Y &y, const Z &z) {
+  return detail::is_in_active_volume(x, y, z) &&
+         (z < kRecoGapMinZ || z > kRecoGapMaxZ);
+}
+
+} // namespace fiducial
+
+} // namespace analysis
+
+#endif

--- a/src/PreSelection.cc
+++ b/src/PreSelection.cc
@@ -1,5 +1,7 @@
 #include "rarexsec/PreSelection.h"
 
+#include "rarexsec/FiducialVolume.h"
+
 #include "ROOT/RVec.hxx"
 
 namespace analysis {
@@ -41,10 +43,11 @@ ROOT::RDF::RNode PreSelection::process(ROOT::RDF::RNode df,
 
   node = node.Define(
       "in_reco_fiducial",
-      "reco_neutrino_vertex_sce_x > 5 && reco_neutrino_vertex_sce_x < 251 && "
-      "reco_neutrino_vertex_sce_y > -110 && reco_neutrino_vertex_sce_y < 110 && "
-      "reco_neutrino_vertex_sce_z > 20 && reco_neutrino_vertex_sce_z < 986 && "
-      "(reco_neutrino_vertex_sce_z < 675 || reco_neutrino_vertex_sce_z > 775)");
+      [](const auto &x, const auto &y, const auto &z) {
+        return fiducial::is_in_reco_volume(x, y, z);
+      },
+      {"reco_neutrino_vertex_sce_x", "reco_neutrino_vertex_sce_y",
+       "reco_neutrino_vertex_sce_z"});
 
   if (!node.HasColumn("n_pfps_gen2")) {
     node = node.Define(
@@ -111,9 +114,8 @@ ROOT::RDF::RNode PreSelection::process(ROOT::RDF::RNode df,
 
   node = node.Define(
       "pass_fv",
-      [](float x, float y, float z) {
-        return x > 5.f && x < 251.f && y > -110.f && y < 110.f &&
-               z > 20.f && z < 986.f && (z < 675.f || z > 775.f);
+      [](const auto &x, const auto &y, const auto &z) {
+        return fiducial::is_in_reco_volume(x, y, z);
       },
       {"reco_neutrino_vertex_sce_x", "reco_neutrino_vertex_sce_y",
        "reco_neutrino_vertex_sce_z"});

--- a/src/TruthClassifier.cc
+++ b/src/TruthClassifier.cc
@@ -1,5 +1,7 @@
 #include "rarexsec/TruthClassifier.h"
 
+#include "rarexsec/FiducialVolume.h"
+
 #include <cmath>
 #include <iostream>
 #include <map>
@@ -67,9 +69,10 @@ ROOT::RDF::RNode TruthClassifier::processNonMc(ROOT::RDF::RNode df,
 ROOT::RDF::RNode TruthClassifier::defineCounts(ROOT::RDF::RNode df) const {
   auto fid_df = df.Define(
       "in_fiducial",
-      "(neutrino_vertex_x > 5 && neutrino_vertex_x < 251) &&"
-      "(neutrino_vertex_y > -110 && neutrino_vertex_y < 110) &&"
-      "(neutrino_vertex_z > 20 && neutrino_vertex_z < 986)");
+      [](const auto &x, const auto &y, const auto &z) {
+        return fiducial::is_in_truth_volume(x, y, z);
+      },
+      {"neutrino_vertex_x", "neutrino_vertex_y", "neutrino_vertex_z"});
 
   auto strange_df = fid_df.Define(
       "mc_n_strange",


### PR DESCRIPTION
## Summary
- nest the fiducial volume helpers under `analysis::fiducial` to match existing namespace style
- rename helper functions to snake_case and update the pre-selection and truth classifier call sites

## Testing
- not run (missing build configuration)


------
https://chatgpt.com/codex/tasks/task_e_68da998307e4832eb4d123502b903977