### PR TITLE
Fix generic lambdas in PreSelection ROOT Define calls

### DIFF
--- a/src/PreSelection.cc
+++ b/src/PreSelection.cc
@@ -43,7 +43,7 @@ ROOT::RDF::RNode PreSelection::process(ROOT::RDF::RNode df,
 
   node = node.Define(
       "in_reco_fiducial",
-      [](const auto &x, const auto &y, const auto &z) {
+      [](float x, float y, float z) {
         return fiducial::is_in_reco_volume(x, y, z);
       },
       {"reco_neutrino_vertex_sce_x", "reco_neutrino_vertex_sce_y",
@@ -114,7 +114,7 @@ ROOT::RDF::RNode PreSelection::process(ROOT::RDF::RNode df,
 
   node = node.Define(
       "pass_fv",
-      [](const auto &x, const auto &y, const auto &z) {
+      [](float x, float y, float z) {
         return fiducial::is_in_reco_volume(x, y, z);
       },
       {"reco_neutrino_vertex_sce_x", "reco_neutrino_vertex_sce_y",


### PR DESCRIPTION
## Summary
- replace the templated generic lambdas used for fiducial volume checks with float-typed lambdas so ROOT's CallableTraits can deduce the return type

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9bb8e350832e8fabad7be0a178a6