### PR TITLE
Fix fiducial volume include path for build

### DIFF
--- a/src/PreSelection.cc
+++ b/src/PreSelection.cc
@@ -1,6 +1,6 @@
 #include "faint/PreSelection.h"
 
-#include "rarexsec/FiducialVolume.h"
+#include "faint/FiducialVolume.h"
 
 #include "ROOT/RVec.hxx"
 

--- a/src/TruthClassifier.cc
+++ b/src/TruthClassifier.cc
@@ -1,6 +1,6 @@
 #include "faint/TruthClassifier.h"
 
-#include "rarexsec/FiducialVolume.h"
+#include "faint/FiducialVolume.h"
 
 #include <cmath>
 #include <iostream>


### PR DESCRIPTION
## Summary
- update PreSelection and TruthClassifier to include the local fiducial volume header
- allow the build to find the correct header when rarexsec is unavailable

## Testing
- `cd build && make` *(fails: ROOT not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da9dbf8b6c832e97c7be130b962fcb