### PR TITLE
Move Campaign implementation to source file

### DIFF
--- a/include/faint/Campaign.h
+++ b/include/faint/Campaign.h
@@ -35,18 +35,9 @@ namespace col {
 inline constexpr const char* Weight = "nominal_event_weight";
 }
 
-inline std::string run_config_path() {
-    const char* env = gSystem->Getenv("FAINT_RUN_CONFIG");
-    if (env) return env;
-    std::string cwd = gSystem->pwd();
-    return cwd + "/data/samples.json";
-}
+std::string run_config_path();
 
-inline std::string ntuple_directory() {
-    const char* env = gSystem->Getenv("FAINT_NTUPLES");
-    if (!env) throw std::runtime_error("Set FAINT_NTUPLES to the directory containing faint ntuples");
-    return env;
-}
+std::string ntuple_directory();
 
 struct Options {
     std::string beam;
@@ -57,49 +48,19 @@ struct Options {
 
 class Campaign {
 public:
-    static Campaign open(const std::string& run_config_json, Options opt, Variables vars = Variables{}) {
-        Campaign s;
-        s.runs_ = RunCatalog::fromFile(run_config_json);
-        s.vars_ = std::move(vars);
-        s.opt_ = std::move(opt);
-        s.set_ = std::make_unique<SampleSet>(s.runs_, s.vars_, s.opt_.beam, s.opt_.periods, s.opt_.ntuple_dir, s.opt_.blind);
-        return s;
-    }
+    static Campaign open(const std::string& run_config_json, Options opt, Variables vars = Variables{});
 
-    std::vector<std::string> sample_keys(Origin origin_filter = Origin::kUnknown) const {
-        std::vector<std::string> out;
-        for (auto const& kv : set().frames()) {
-            const auto& key = kv.first;
-            const auto& s = kv.second;
-            if (origin_filter == Origin::kUnknown || s.origin_ == origin_filter) out.push_back(key.str());
-        }
-        std::sort(out.begin(), out.end());
-        return out;
-    }
+    std::vector<std::string> sample_keys(Origin origin_filter = Origin::kUnknown) const;
 
-    ROOT::RDF::RNode df(std::string_view sample_key, Variation v = Variation::kCV) const {
-        const Sample* s = find_sample(sample_key);
-        if (!s) throw std::runtime_error(std::string("Sample not found: ") + std::string(sample_key));
-        if (v == Variation::kCV) return s->node_;
-        auto it = s->variations_.find(v);
-        return (it != s->variations_.end()) ? it->second : s->node_;
-    }
+    ROOT::RDF::RNode df(std::string_view sample_key, Variation v = Variation::kCV) const;
 
-    ROOT::RDF::RNode final(std::string_view key, Variation v = Variation::kCV) const {
-        return df(key, v).Filter(sel::Final);
-    }
+    ROOT::RDF::RNode final(std::string_view key, Variation v = Variation::kCV) const;
 
-    ROOT::RDF::RNode quality(std::string_view key, Variation v = Variation::kCV) const {
-        return df(key, v).Filter(sel::Quality);
-    }
+    ROOT::RDF::RNode quality(std::string_view key, Variation v = Variation::kCV) const;
 
-    void snapshot_where(const std::string& filter, const std::string& out_file, const std::vector<std::string>& columns = {}) const {
-        set().snapshot(filter, out_file, columns);
-    }
+    void snapshot_where(const std::string& filter, const std::string& out_file, const std::vector<std::string>& columns = {}) const;
 
-    void snapshot_final(const std::string& out_file, const std::vector<std::string>& columns = {}) const {
-        snapshot_where(sel::Final, out_file, columns);
-    }
+    void snapshot_final(const std::string& out_file, const std::vector<std::string>& columns = {}) const;
 
     double pot() const noexcept { return set().total_pot(); }
 
@@ -121,12 +82,7 @@ private:
 
     const SampleSet& set() const { return *set_; }
 
-    const Sample* find_sample(std::string_view key) const {
-        for (auto const& kv : set().frames()) {
-            if (kv.first.str() == key) return &kv.second;
-        }
-        return nullptr;
-    }
+    const Sample* find_sample(std::string_view key) const;
 };
 
 } // namespace campaign

--- a/src/Campaign.cc
+++ b/src/Campaign.cc
@@ -1,0 +1,86 @@
+#include "faint/Campaign.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace faint {
+namespace campaign {
+
+std::string run_config_path() {
+    const char* env = gSystem->Getenv("FAINT_RUN_CONFIG");
+    if (env) return env;
+    std::string cwd = gSystem->pwd();
+    return cwd + "/data/samples.json";
+}
+
+std::string ntuple_directory() {
+    const char* env = gSystem->Getenv("FAINT_NTUPLES");
+    if (!env) throw std::runtime_error("Set FAINT_NTUPLES to the directory containing faint ntuples");
+    return env;
+}
+
+Campaign Campaign::open(const std::string& run_config_json, Options opt, Variables vars) {
+    Campaign s;
+    s.runs_ = RunCatalog::fromFile(run_config_json);
+    s.vars_ = std::move(vars);
+    s.opt_ = std::move(opt);
+    s.set_ = std::make_unique<SampleSet>(
+        s.runs_, s.vars_, s.opt_.beam, s.opt_.periods, s.opt_.ntuple_dir, s.opt_.blind);
+    return s;
+}
+
+std::vector<std::string> Campaign::sample_keys(Origin origin_filter) const {
+    std::vector<std::string> out;
+    const auto& frames = const_cast<SampleSet&>(set()).frames();
+    for (auto const& kv : frames) {
+        const auto& key = kv.first;
+        const auto& sample = kv.second;
+        if (origin_filter == Origin::kUnknown || sample.origin_ == origin_filter) {
+            out.push_back(key.str());
+        }
+    }
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
+ROOT::RDF::RNode Campaign::df(std::string_view sample_key, Variation v) const {
+    const Sample* sample = find_sample(sample_key);
+    if (!sample) {
+        throw std::runtime_error(std::string("Sample not found: ") + std::string(sample_key));
+    }
+    if (v == Variation::kCV) return sample->node_;
+    auto it = sample->variations_.find(v);
+    return (it != sample->variations_.end()) ? it->second : sample->node_;
+}
+
+ROOT::RDF::RNode Campaign::final(std::string_view key, Variation v) const {
+    return df(key, v).Filter(sel::Final);
+}
+
+ROOT::RDF::RNode Campaign::quality(std::string_view key, Variation v) const {
+    return df(key, v).Filter(sel::Quality);
+}
+
+void Campaign::snapshot_where(const std::string& filter,
+                              const std::string& out_file,
+                              const std::vector<std::string>& columns) const {
+    set().snapshot(filter, out_file, columns);
+}
+
+void Campaign::snapshot_final(const std::string& out_file,
+                              const std::vector<std::string>& columns) const {
+    snapshot_where(sel::Final, out_file, columns);
+}
+
+const Sample* Campaign::find_sample(std::string_view key) const {
+    const auto& frames = const_cast<SampleSet&>(set()).frames();
+    for (auto const& kv : frames) {
+        if (kv.first.str() == key) return &kv.second;
+    }
+    return nullptr;
+}
+
+} // namespace campaign
+} // namespace faint

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -1,0 +1,3 @@
+#include "faint/Dataset.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/EventProcessor.cc
+++ b/src/EventProcessor.cc
@@ -1,0 +1,3 @@
+#include "faint/EventProcessor.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/FiducialVolume.cc
+++ b/src/FiducialVolume.cc
@@ -1,0 +1,3 @@
+#include "faint/FiducialVolume.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/Run.cc
+++ b/src/Run.cc
@@ -1,0 +1,3 @@
+#include "faint/Run.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/RunReader.cc
+++ b/src/RunReader.cc
@@ -1,0 +1,3 @@
+#include "faint/RunReader.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/Sample.cc
+++ b/src/Sample.cc
@@ -1,0 +1,3 @@
+#include "faint/Sample.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/SampleSet.cc
+++ b/src/SampleSet.cc
@@ -1,0 +1,3 @@
+#include "faint/SampleSet.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/Types.cc
+++ b/src/Types.cc
@@ -1,0 +1,3 @@
+#include "faint/Types.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/Variables.cc
+++ b/src/Variables.cc
@@ -1,0 +1,3 @@
+#include "faint/Variables.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/Weighter.cc
+++ b/src/Weighter.cc
@@ -1,0 +1,3 @@
+#include "faint/Weighter.h"
+
+// Translation unit generated to accompany the header-only implementation.

--- a/src/faintLinkDef.cc
+++ b/src/faintLinkDef.cc
@@ -1,0 +1,3 @@
+#include "faintLinkDef.h"
+
+// Translation unit generated to accompany the ROOT dictionary header.


### PR DESCRIPTION
## Summary
- move the Campaign helper functions and member function definitions out of the header
- implement the Campaign data accessors in the corresponding translation unit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9f42a40c832ebde461f7433c16cb