### PR TITLE
Fix EventProcessor references in sample management

### DIFF
--- a/include/faint/Sample.h
+++ b/include/faint/Sample.h
@@ -19,7 +19,7 @@ class Sample {
  public:
   Sample(const nlohmann::json& j, const nlohmann::json& all,
          const std::string& base_dir, const VariableRegistry& vars,
-         IEventProcessor& processor);
+         EventProcessor& processor);
 
   const SampleKey& key() const noexcept { return key_; }
   SampleOrigin origin() const noexcept { return origin_; }
@@ -50,7 +50,7 @@ class Sample {
 
   SampleVariation parse_variation(const std::string& s) const;
   ROOT::RDF::RNode build(const std::string& base_dir, const VariableRegistry& vars,
-                         IEventProcessor& processor, const std::string& rel,
+                         EventProcessor& processor, const std::string& rel,
                          const nlohmann::json& all);
 };
 

--- a/include/faint/SampleSet.h
+++ b/include/faint/SampleSet.h
@@ -9,6 +9,8 @@
 
 #include "ROOT/RDataFrame.hxx"
 
+#include <nlohmann/json_fwd.hpp>
+
 #include "faint/PreSelection.h"
 #include "faint/Run.h"
 #include "faint/RunCatalog.h"
@@ -17,10 +19,6 @@
 #include "faint/TruthClassifier.h"
 #include "faint/Variables.h"
 #include "faint/Weighter.h"
-
-namespace nlohmann {
-class json;
-}
 
 namespace faint {
 
@@ -62,12 +60,12 @@ class SampleSet {
   long total_triggers_;
 
   Map samples_;
-  std::vector<std::unique_ptr<IEventProcessor>> processors_;
+  std::vector<std::unique_ptr<EventProcessor>> processors_;
   std::unordered_map<SampleKey, const Run*> run_cache_;
 
   void build();
   void add_run(const Run& rc);
-  std::unique_ptr<IEventProcessor> build_pipeline(const nlohmann::json& sample);
+  std::unique_ptr<EventProcessor> build_pipeline(const nlohmann::json& sample);
   void snapshot_impl(const std::string& filter, const std::string& out,
                      const std::vector<std::string>& cols) const;
 };

--- a/src/Sample.cc
+++ b/src/Sample.cc
@@ -9,7 +9,7 @@ namespace faint {
 namespace {
 
 ROOT::RDF::RNode open_frame(const std::string& base_dir, const std::string& rel,
-                            IEventProcessor& processor, SampleOrigin origin) {
+                            EventProcessor& processor, SampleOrigin origin) {
   auto path = base_dir + "/" + rel;
   ROOT::RDataFrame df("nuselection/EventSelectionFilter", path);
   return processor.process(df, origin);
@@ -44,7 +44,7 @@ ROOT::RDF::RNode exclude_truth(ROOT::RDF::RNode df,
 
 Sample::Sample(const nlohmann::json& j, const nlohmann::json& all,
                const std::string& base_dir, const VariableRegistry& vars,
-               IEventProcessor& processor)
+               EventProcessor& processor)
     : key_{j.at("sample_key").get<std::string>()},
       origin_{[&]() {
         auto ts = j.at("sample_type").get<std::string>();
@@ -119,7 +119,7 @@ SampleVariation Sample::parse_variation(const std::string& s) const {
 
 ROOT::RDF::RNode Sample::build(const std::string& base_dir,
                                const VariableRegistry& vars,
-                               IEventProcessor& processor,
+                               EventProcessor& processor,
                                const std::string& rel,
                                const nlohmann::json& all) {
   auto df = open_frame(base_dir, rel, processor, origin_);

--- a/src/SampleSet.cc
+++ b/src/SampleSet.cc
@@ -104,7 +104,7 @@ void SampleSet::add_run(const Run& rc) {
   }
 }
 
-std::unique_ptr<IEventProcessor> SampleSet::build_pipeline(
+  std::unique_ptr<EventProcessor> SampleSet::build_pipeline(
     const nlohmann::json& sample) {
   auto weighter =
       std::make_unique<Weighter>(sample, total_pot_, total_triggers_);


### PR DESCRIPTION
## Summary
- replace outdated `IEventProcessor` references in the sample classes with the existing `EventProcessor` type
- include the nlohmann json forward declaration header to avoid ambiguity in `SampleSet`

## Testing
- make -C build *(fails: ROOT headers unavailable in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dab0994648832ebecefc03d23cca0e