### PR TITLE
Ensure faint ROOT helper locates nlohmann json headers

### DIFF
--- a/scripts/faint-root.sh
+++ b/scripts/faint-root.sh
@@ -12,6 +12,17 @@ LIBDIR="${TOPDIR}/build/lib"
 INCDIR="${TOPDIR}/include"
 MACRO="${TOPDIR}/scripts/setup_faint.C"
 
+# Allow users to provide an external nlohmann/json install via common
+# environment variables.  ROOT needs the headers to be discoverable at
+# runtime when executing macros, but ROOT_INCLUDE_PATH is not aware of the
+# UPS-style variables (e.g. NLOHMANN_JSON_INC).  If either JSON_INC or
+# NLOHMANN_JSON_INC are set, prepend them so that the headers are available
+# during the session.
+JSON_INC_PATH="${JSON_INC:-${NLOHMANN_JSON_INC:-}}"
+if [ -n "${JSON_INC_PATH}" ]; then
+  export ROOT_INCLUDE_PATH="${JSON_INC_PATH}:${ROOT_INCLUDE_PATH}"
+fi
+
 # Ensure library path and includes are visible to ROOT
 case "$(uname -s)" in
   Darwin) export DYLD_LIBRARY_PATH="${LIBDIR}:${DYLD_LIBRARY_PATH}" ;;


### PR DESCRIPTION
## Summary
- detect JSON_INC or NLOHMANN_JSON_INC in faint-root helper
- prepend the resolved path to ROOT_INCLUDE_PATH so ROOT can locate nlohmann/json headers

## Testing
- bash -n scripts/faint-root.sh

------
https://chatgpt.com/codex/tasks/task_e_68dab8643f04832eb3db13b648aab045