### PR TITLE
Fix ROOT setup header list

### DIFF
--- a/scripts/setup_faint.C
+++ b/scripts/setup_faint.C
@@ -154,7 +154,7 @@ void setup_faint(const char* abs_lib_path = nullptr, const char* abs_inc_dir = n
   if (!include_dir.empty()) {
     load_header("faint/Types.h");
     load_header("faint/SampleSet.h");
-    load_header("faint/NuMuCCSelector.h");
+    load_header("faint/PreSelection.h");
     load_header("faint/TruthClassifier.h");
     load_header("faint/MuonSelector.h");
     load_header("faint/Weighter.h");


### PR DESCRIPTION
## Summary
- replace the obsolete NuMuCCSelector helper include with PreSelection so ROOT macros load the available header

## Testing
- `./scripts/faint-root.sh -b -q src/example_macro.C` *(fails: `root` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dababba5f8832e9cd53acdcda7361e