### PR TITLE
Silence ROOT PCM load noise

### DIFF
--- a/scripts/setup_faint.C
+++ b/scripts/setup_faint.C
@@ -4,11 +4,28 @@
 #include <iostream>
 #include <string>
 
+#include "TError.h"
 #include "TInterpreter.h"
 #include "TROOT.h"
 #include "TSystem.h"
 
 namespace {
+
+class ErrorLevelGuard {
+public:
+  explicit ErrorLevelGuard(int new_level)
+      : previous_level_(gErrorIgnoreLevel) {
+    gErrorIgnoreLevel = new_level;
+  }
+
+  ErrorLevelGuard(const ErrorLevelGuard&) = delete;
+  ErrorLevelGuard& operator=(const ErrorLevelGuard&) = delete;
+
+  ~ErrorLevelGuard() { gErrorIgnoreLevel = previous_level_; }
+
+private:
+  int previous_level_;
+};
 
 std::string get_env(const char* name) {
   if (name == nullptr) {
@@ -91,6 +108,7 @@ void load_header(const std::string& h) {
 }
 
 void setup_faint(const char* abs_lib_path = nullptr, const char* abs_inc_dir = nullptr) {
+  ErrorLevelGuard error_level_guard(kFatal);
   // Some ROOT 6 builds need libGraf preloaded for dictionaries
   if (gROOT->GetVersionInt() >= 60000) {
     if (gSystem->Load("libGraf") != 0) {


### PR DESCRIPTION
## Summary
- add a guard in `setup_faint.C` to temporarily raise ROOT's error ignore level while loading FAINT
- include `TError.h` so the guard can use the ROOT logging constants

## Testing
- not run (ROOT is not available in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68dad810fa68832e8560f642f9bc0c07