### PR TITLE
Fix dataset cache construction without default RNode

### DIFF
--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -129,8 +129,9 @@ void Dataset::build_dataset_cache() {
     datasets_.clear();
     auto& frames = const_cast<SampleSet&>(set()).frames();
     for (auto& [key, sample] : frames) {
-        Variations variations;
-        variations.nominal = make_entry(sample, SampleVariation::kCV, sample.nominal());
+        Variations variations{
+            make_entry(sample, SampleVariation::kCV, sample.nominal()), {}
+        };
         for (auto const& [variation, node] : sample.variations()) {
             variations.variations.emplace(variation, make_entry(sample, variation, node));
         }


### PR DESCRIPTION
## Summary
- initialize dataset cache variations with constructed entries to avoid default-constructing ROOT RNode instances

## Testing
- make -C build *(fails: ROOT not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc6d9a1d0832e99b5b94e4a2dec58