### PR TITLE
Remove redundant FiducialVolume translation unit

### DIFF
--- a/src/FiducialVolume.cc
+++ b/src/FiducialVolume.cc
@@ -1,3 +1,0 @@
-#include "faint/FiducialVolume.h"
-
-// Translation unit generated to accompany the header-only implementation.


### PR DESCRIPTION
## Summary
- remove the unused FiducialVolume translation unit now that the implementation is header-only

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbce71cc40832eae71d7486ec37cfc