### PR TITLE
Fix Dataset Entry default construction

### DIFF
--- a/include/faint/Dataset.h
+++ b/include/faint/Dataset.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -55,7 +56,21 @@ public:
     struct Entry {
         SampleOrigin origin{SampleOrigin::kUnknown};
         SampleRole role{SampleRole::kNominal};
-        mutable ROOT::RDF::RNode dataframe;
+
+        Entry() = default;
+
+        Entry(SampleOrigin origin, SampleRole role, ROOT::RDF::RNode node)
+            : origin(origin), role(role), dataframe_(std::move(node)) {}
+
+        ROOT::RDF::RNode dataframe() const {
+            if (!dataframe_) {
+                throw std::runtime_error("Dataset entry does not hold a dataframe");
+            }
+            return *dataframe_;
+        }
+
+    private:
+        mutable std::optional<ROOT::RDF::RNode> dataframe_;
     };
 
     struct Variations {

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -82,10 +82,10 @@ ROOT::RDF::RNode Dataset::df(std::string_view sample_key,
     if (!variations) {
         throw std::runtime_error(std::string("Sample not found: ") + std::string(sample_key));
     }
-    if (v == SampleVariation::kCV) return variations->nominal.dataframe;
+    if (v == SampleVariation::kCV) return variations->nominal.dataframe();
     auto it = variations->variations.find(v);
-    return (it != variations->variations.end()) ? it->second.dataframe
-                                                : variations->nominal.dataframe;
+    return (it != variations->variations.end()) ? it->second.dataframe()
+                                                : variations->nominal.dataframe();
 }
 
 ROOT::RDF::RNode Dataset::final(std::string_view key,


### PR DESCRIPTION
## Summary
- store dataset entry dataframes in an optional so ROOT can default-construct map elements
- expose an accessor for the stored dataframe and update callers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe383d630832ebe3f369a2058c4b5