### PR TITLE
Rename systematics headers to noun-focused names

### DIFF
--- a/include/faint/syst/SelectionManagerSystematics.h
+++ b/include/faint/syst/SelectionManagerSystematics.h
@@ -1,11 +1,11 @@
-#ifndef FAINT_SYST_SELECTION_MANAGER_ADAPTER_H
-#define FAINT_SYST_SELECTION_MANAGER_ADAPTER_H
+#ifndef FAINT_SYST_SELECTION_MANAGER_SYSTEMATICS_H
+#define FAINT_SYST_SELECTION_MANAGER_SYSTEMATICS_H
 
 #include <map>
 #include <string>
 #include <vector>
 
-#include <faint/syst/systematics_registry.h>
+#include <faint/syst/SystematicsRegistry.h>
 
 namespace faint {
 namespace syst {
@@ -39,4 +39,4 @@ inline std::vector<std::string> selection_manager_systematic_names() {
 } // namespace syst
 } // namespace faint
 
-#endif // FAINT_SYST_SELECTION_MANAGER_ADAPTER_H
+#endif // FAINT_SYST_SELECTION_MANAGER_SYSTEMATICS_H

--- a/include/faint/syst/SystematicsRdf.h
+++ b/include/faint/syst/SystematicsRdf.h
@@ -1,5 +1,5 @@
-#ifndef FAINT_SYSTEMATICS_RDF_H
-#define FAINT_SYSTEMATICS_RDF_H
+#ifndef FAINT_SYST_SYSTEMATICS_RDF_H
+#define FAINT_SYST_SYSTEMATICS_RDF_H
 
 #include <cmath>
 #include <string>
@@ -11,7 +11,7 @@
 #include "TH2D.h"
 #include "TMatrixD.h"
 
-#include <faint/syst/systematics_registry.h>
+#include <faint/syst/SystematicsRegistry.h>
 
 namespace faint {
 namespace syst {
@@ -160,4 +160,4 @@ inline TMatrixD covariance_matrix_from_histograms(const TH1D* cv_hist,
 } // namespace syst
 } // namespace faint
 
-#endif // FAINT_SYSTEMATICS_RDF_H
+#endif // FAINT_SYST_SYSTEMATICS_RDF_H

--- a/include/faint/syst/SystematicsRegistry.h
+++ b/include/faint/syst/SystematicsRegistry.h
@@ -1,5 +1,5 @@
-#ifndef FAINT_SYSTEMATICS_REGISTRY_H
-#define FAINT_SYSTEMATICS_REGISTRY_H
+#ifndef FAINT_SYST_SYSTEMATICS_REGISTRY_H
+#define FAINT_SYST_SYSTEMATICS_REGISTRY_H
 
 #include <string>
 #include <utility>
@@ -67,4 +67,4 @@ inline std::vector<SystematicDescriptor> systematic_list_from_variables() {
 } // namespace syst
 } // namespace faint
 
-#endif // FAINT_SYSTEMATICS_REGISTRY_H
+#endif // FAINT_SYST_SYSTEMATICS_REGISTRY_H

--- a/macros/systematics_error_band_example.C
+++ b/macros/systematics_error_band_example.C
@@ -10,7 +10,7 @@
 #include <faint/Log.h>
 #include <faint/Types.h>
 #include <faint/plot/ErrorBandBuilder.h>
-#include <faint/syst/systematics_rdf.h>
+#include <faint/syst/SystematicsRdf.h>
 
 #include <algorithm>
 #include <iostream>


### PR DESCRIPTION
## Summary
- rename the systematics headers to noun-focused PascalCase names
- update include guards and dependent includes to use the new header names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe4aee074832ebb78e438c5d52bcc