### PR TITLE
Refactor RunReader initialization to load from file path

### DIFF
--- a/include/faint/Dataset.h
+++ b/include/faint/Dataset.h
@@ -116,6 +116,8 @@ public:
     const Map& datasets() const noexcept { return datasets_; }
 
 private:
+    Dataset(RunReader runs, Options opt, Variables vars);
+
     RunReader runs_;
     Variables vars_;
     Options opt_;

--- a/include/faint/Run.h
+++ b/include/faint/Run.h
@@ -29,21 +29,18 @@ struct Run {
 
 class RunReader {
 public:
+  RunReader() = default;
+  explicit RunReader(const std::string& path);
+
   void add(Run rc);
 
   const Run& get(const std::string& beam, const std::string& period) const;
 
   const std::map<std::string, Run>& all() const noexcept;
 
-  static RunReader from_json(const nlohmann::json& data);
-
-  static RunReader from_file(const std::string& path);
-
-  static RunReader read(const nlohmann::json& data) { return from_json(data); }
-
-  static RunReader read(const std::string& path) { return from_file(path); }
-
 private:
+  void load_from_json(const nlohmann::json& data);
+
   std::map<std::string, Run> configs_;
 };
 

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -11,6 +11,15 @@
 namespace faint {
 namespace dataset {
 
+Dataset::Dataset(RunReader runs, Options opt, Variables vars)
+    : runs_(std::move(runs)),
+      vars_(std::move(vars)),
+      opt_(std::move(opt)),
+      set_(std::make_unique<SampleSet>(runs_, vars_, opt_.beam, opt_.periods,
+                                       opt_.ntuple_dir, opt_.blind)) {
+    build_dataset_cache();
+}
+
 std::string run_config_path() {
     const char* env = gSystem->Getenv("FAINT_RUN_CONFIG");
     if (env) return env;
@@ -51,15 +60,7 @@ std::string ntuple_directory(const std::string& run_config_json) {
 }
 
 Dataset Dataset::open(const std::string& run_config_json, Options opt, Variables vars) {
-    Dataset dataset;
-    dataset.runs_ = RunReader::from_file(run_config_json);
-    dataset.vars_ = std::move(vars);
-    dataset.opt_ = std::move(opt);
-    dataset.set_ = std::make_unique<SampleSet>(
-        dataset.runs_, dataset.vars_, dataset.opt_.beam, dataset.opt_.periods,
-        dataset.opt_.ntuple_dir, dataset.opt_.blind);
-    dataset.build_dataset_cache();
-    return dataset;
+    return Dataset(RunReader(run_config_json), std::move(opt), std::move(vars));
 }
 
 std::vector<std::string> Dataset::sample_keys(


### PR DESCRIPTION
## Summary
- add a RunReader constructor that loads run configurations directly from a file path
- initialize Dataset with a fully constructed RunReader to avoid post-construction assignment

## Testing
- ninja -C build *(fails: build.ninja not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe7348408832ea6bbbf5d6eb010db