### PR TITLE
Include TMatrixDSym definition for optional

### DIFF
--- a/include/faint/plot/ChiSquaredCalculator.h
+++ b/include/faint/plot/ChiSquaredCalculator.h
@@ -5,8 +5,9 @@
 #include <utility>
 #include <vector>
 
+#include "TMatrixDSym.h"
+
 class TH1D;
-class TMatrixDSym;
 
 namespace faint {
 namespace plot {


### PR DESCRIPTION
## Summary
- include the ROOT TMatrixDSym header in ChiSquaredCalculator so the class is complete when used with std::optional

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe88e4720832e9e5e683f4700a432