### PR TITLE
Inline ntuple directory parsing in Dataset::open

### DIFF
--- a/include/faint/Dataset.h
+++ b/include/faint/Dataset.h
@@ -25,10 +25,6 @@ namespace dataset {
 
 std::string run_config_path();
 
-std::string ntuple_directory();
-
-std::string ntuple_directory(const std::string& run_config_json);
-
 struct Options {
     std::string beam;
     std::vector<std::string> periods;

--- a/install/include/faint/Dataset.h
+++ b/install/include/faint/Dataset.h
@@ -39,10 +39,6 @@ inline constexpr const char* Weight = "nominal_event_weight";
 
 std::string run_config_path();
 
-std::string ntuple_directory();
-
-std::string ntuple_directory(const std::string& run_config_json);
-
 struct Options {
     std::string beam;
     std::vector<std::string> periods;

--- a/src/Dataset.cc
+++ b/src/Dataset.cc
@@ -27,17 +27,14 @@ std::string run_config_path() {
     return cwd + "/data/samples.json";
 }
 
-std::string ntuple_directory() {
-    return ntuple_directory(run_config_path());
-}
-
-std::string ntuple_directory(const std::string& run_config_json) {
+Dataset Dataset::open(const std::string& run_config_json, Options opt, Variables vars) {
     const auto& config_path = run_config_json;
     std::ifstream input(config_path);
     if (!input.is_open()) {
         throw std::runtime_error("Could not open run configuration: " + config_path);
     }
 
+    std::string ntuple_dir;
     try {
         auto data = nlohmann::json::parse(input);
         if (data.contains("samples")) {
@@ -48,19 +45,14 @@ std::string ntuple_directory(const std::string& run_config_json) {
             throw std::runtime_error("Run configuration missing 'ntupledir' entry");
         }
 
-        auto dir = data.at("ntupledir").get<std::string>();
-        if (dir.empty()) {
+        ntuple_dir = data.at("ntupledir").get<std::string>();
+        if (ntuple_dir.empty()) {
             throw std::runtime_error("Run configuration has empty 'ntupledir'");
         }
-
-        return dir;
     } catch (const nlohmann::json::exception& e) {
         throw std::runtime_error(std::string{"Failed to parse run configuration: "} + e.what());
     }
-}
 
-Dataset Dataset::open(const std::string& run_config_json, Options opt, Variables vars) {
-    auto ntuple_dir = ntuple_directory(run_config_json);
     return Dataset(RunReader(run_config_json), std::move(ntuple_dir), std::move(opt),
                    std::move(vars));
 }


### PR DESCRIPTION
## Summary
- stop exporting the `ntuple_directory` helper from the Dataset headers
- inline the run-configuration parsing logic directly inside `Dataset::open`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf1260ea4832eb62ab6f1f19edeca