### PR TITLE
Replace faint references with rarexsec naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Framework for Analysis of Infrequent cross‑secTions
 
-The FAINT project provides reusable building blocks for neutrino cross-section
+The rarexsec project provides reusable building blocks for neutrino cross-section
 studies together with helper scripts and example ROOT macros.
 
 ## Prerequisites
@@ -24,8 +24,8 @@ You can quickly check that ROOT is discoverable with `root-config --version`.
 
 1. Clone the repository and enter it:
    ```bash
-   git clone https://github.com/<your-org>/faint.git
-   cd faint
+   git clone https://github.com/<your-org>/rarexsec.git
+   cd rarexsec
    ```
 2. Build the project libraries from the provided `build/Makefile`:
    ```bash
@@ -44,25 +44,25 @@ and static libraries only; dictionary generation is skipped in that case.
 
 ## Running the example ROOT macro
 
-After building, the faint libraries must be discoverable by ROOT.  The
-`scripts/faint-root.sh` wrapper sets up the include and library paths and
+After building, the rarexsec libraries must be discoverable by ROOT.  The
+`rarexsec-root.sh` wrapper sets up the include and library paths and
 executes any macro you pass to it.  From the repository root run:
 
 ```bash
-./scripts/faint-root.sh -b -q macros/example_macro.C
+./rarexsec-root.sh -b -q macros/example_macro.C
 ```
 
 This command loads the generated libraries, configures ROOT include paths, and
 runs the `example_macro()` entry point defined in `macros/example_macro.C`.  Drop
-`-b -q` to open an interactive ROOT session preloaded with the FAINT API.
+`-b -q` to open an interactive ROOT session preloaded with the rarexsec API.
 
 Alternatively, you can call the setup macro manually from ROOT by providing the
 absolute library and include directories:
 
 ```bash
-root -l -q -e 'setup_faint("$PWD/build/lib/libfaint.so","$PWD/include")' macros/example_macro.C
+root -l -q -e 'setup_rarexsec("$PWD/build/lib/librarexsec.so","$PWD/include")' macros/example_macro.C
 ```
 
 Replace the library suffix with `.dylib` on macOS.  Once the environment is
-configured, any custom macro can use the headers under `include/faint/` and
+configured, any custom macro can use the headers under `include/rarexsec/` and
 link against the libraries in `build/lib/`.

--- a/build/Makefile
+++ b/build/Makefile
@@ -5,20 +5,20 @@ BUILD_DIR := $(TOP_DIR)/build
 OBJ_DIR := $(BUILD_DIR)/obj
 LIB_DIR := $(BUILD_DIR)/lib
 
-SCRIPTDIR   := $(TOP_DIR)/scripts
+SCRIPTDIR   := $(TOP_DIR)
 VERSION     ?= $(shell cd $(TOP_DIR) && git describe --tags --always --dirty 2>/dev/null || echo 0.0.0)
 GIT_REV     := $(shell cd $(TOP_DIR) && git rev-parse --short HEAD 2>/dev/null || echo unknown)
 # Extract c++ standard from CXXFLAGS or default:
 CXX_STD_STR ?= $(or $(patsubst -std=%,%,$(filter -std=%,$(CXXFLAGS))),c++17)
 USE_ROOT    ?= yes   # your project uses ROOT; set 'no' if ever optional
 
-CONFIG_IN   := $(SCRIPTDIR)/faint-config.in
-CONFIG_OUT  := $(BUILD_DIR)/bin/faint-config
-ROOT_WRAPPER:= $(SCRIPTDIR)/faint-root.sh
-SETUP_MACRO := $(SCRIPTDIR)/setup_faint.C
+CONFIG_IN   := $(SCRIPTDIR)/rarexsec-config.in
+CONFIG_OUT  := $(BUILD_DIR)/bin/rarexsec-config
+ROOT_WRAPPER:= $(SCRIPTDIR)/rarexsec-root.sh
+SETUP_MACRO := $(SCRIPTDIR)/setup_rarexsec.C
 
-PROJECT_SHARED_LIB_NAME := faint
-ROOT_SHARED_LIB_NAME := faint_root
+PROJECT_SHARED_LIB_NAME := rarexsec
+ROOT_SHARED_LIB_NAME := rarexsec_root
 SHARED_LIB := $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME)
 ROOT_SHARED_LIB := $(LIB_DIR)/lib$(ROOT_SHARED_LIB_NAME)
 
@@ -126,7 +126,7 @@ USER_LDFLAGS := $(LDFLAGS)
 
 BASE_CXXFLAGS := -std=$(CXX_STD) -Wall -Wextra -Wpedantic -fPIC -I$(INCLUDE_DIR) \
                   $(ROOT_CXXFLAGS) $(EXTRA_INC) $(EXTRA_CXXFLAGS) \
-                  -DFAINT_VERSION=\"$(PROJECT_VERSION)\"
+                  -DRAREXSEC_VERSION=\"$(PROJECT_VERSION)\"
 CXXFLAGS := $(OPTFLAGS) $(BASE_CXXFLAGS) $(USER_CXXFLAGS)
 
 LINK_FLAGS := $(ROOT_LDFLAGS) $(EXTRA_LDFLAGS) $(USER_LDFLAGS)
@@ -144,9 +144,9 @@ ifeq ($(strip $(SRCS)),)
   $(warning No sources found under '$(SRC_DIR)'.)
 endif
 
-ROOT_DICT_HEADERS_REL := faint/proc/EventProcessor.h faint/proc/PreSelection.h \
-                          faint/proc/MuonSelector.h faint/Selection.h \
-                          faint/proc/TruthClassifier.h faint/proc/Weighter.h
+ROOT_DICT_HEADERS_REL := rarexsec/proc/EventProcessor.h rarexsec/proc/PreSelection.h \
+                          rarexsec/proc/MuonSelector.h rarexsec/Selection.h \
+                          rarexsec/proc/TruthClassifier.h rarexsec/proc/Weighter.h
 ROOT_DICT_HEADERS := $(addprefix $(INCLUDE_DIR)/,$(ROOT_DICT_HEADERS_REL))
 ROOT_DICT_SRC := $(OBJ_DIR)/$(ROOT_SHARED_LIB_NAME)_dict.cxx
 ROOT_DICT_OBJ := $(OBJ_DIR)/$(ROOT_SHARED_LIB_NAME)_dict.o
@@ -210,12 +210,12 @@ $(LIB_DIR)/lib$(PROJECT_SHARED_LIB_NAME).a: $(OBJS) | $(LIB_DIR)
 	@echo "Built $@"
 
 ifeq ($(USE_ROOT),yes)
-$(ROOT_DICT_OBJ): $(SRC_DIR)/faintLinkDef.h $(ROOT_DICT_HEADERS) | $(OBJ_DIR)
+$(ROOT_DICT_OBJ): $(SRC_DIR)/rarexsecLinkDef.h $(ROOT_DICT_HEADERS) | $(OBJ_DIR)
 	@$(MKDIR) $(dir $@)
 	$(RM) $(ROOT_DICT_SRC) $(ROOT_DICT_PCM)
-	$(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) $(ROOTCLING_CXXFLAGS) $(EXTRA_INC) \
-	$(ROOT_DICT_HEADERS_REL) \
-	$(SRC_DIR)/faintLinkDef.h
+        $(ROOTCLING) -f $(ROOT_DICT_SRC) -c -I$(INCLUDE_DIR) $(ROOTCLING_CXXFLAGS) $(EXTRA_INC) \
+        $(ROOT_DICT_HEADERS_REL) \
+        $(SRC_DIR)/rarexsecLinkDef.h
 	$(CXX) $(CXXFLAGS) -MMD -MP -c $(ROOT_DICT_SRC) -o $@
 
 $(ROOT_SHARED_LIB).$(SOEXT): $(SHARED_LIB).$(SOEXT) $(ROOT_DICT_OBJ) $(ROOT_DICT_PCM_OUT) | $(LIB_DIR)
@@ -240,7 +240,7 @@ ifeq ($(USE_ROOT),yes)
 endif
 	@rsync -a --delete $(INCLUDE_DIR)/ $(INSTALL_INCDIR)/
 	@cp -a $(CONFIG_OUT) $(PREFIX)/bin/
-	@cp -a $(ROOT_WRAPPER) $(PREFIX)/bin/faint-root
+        @cp -a $(ROOT_WRAPPER) $(PREFIX)/bin/rarexsec-root
 	@cp -a $(SETUP_MACRO) $(PREFIX)/scripts/
 	@echo "Installed to $(PREFIX)"
 	@echo "  - libs:    $(INSTALL_LIBDIR)"

--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -1,7 +1,7 @@
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFHelpers.hxx>
 #include <TSystem.h>
-#include <faint/Dataset.h>
+#include <rarexsec/Dataset.h>
 
 #include <iostream>
 #include <stdexcept>
@@ -12,16 +12,16 @@ void example_macro() {
   try {
     ROOT::EnableImplicitMT();
 
-    if (gSystem->Load("libfaint_root")) {
-      throw std::runtime_error("Failed to load libfaint_root library");
+    if (gSystem->Load("librarexsec_root")) {
+      throw std::runtime_error("Failed to load librarexsec_root library");
     }
 
     const std::string config_path = "data/samples.json";
 
-    faint::dataset::Options options;
+    rarexsec::dataset::Options options;
     options.beam = "numi-fhc";
     options.periods = {"run1"};
-    auto dataset = faint::dataset::Dataset::open(config_path, options);
+    auto dataset = rarexsec::dataset::Dataset::open(config_path, options);
 
     std::cout << "Loaded beam " << dataset.beam() << " for";
     for (const auto& period : dataset.periods()) {

--- a/rarexsec-config.in
+++ b/rarexsec-config.in
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# faint-config — print compiler/linker flags and paths for faint
+# rarexsec-config — print compiler/linker flags and paths for rarexsec
 
-# Resolve topdir: prefer FAINT env; else derive from this script location
-if [ -z "$FAINT" ]; then
+# Resolve topdir: prefer RAREXSEC env; else derive from this script location
+if [ -z "$RAREXSEC" ]; then
   topdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 else
-  topdir=${FAINT}
+  topdir=${RAREXSEC}
 fi
 
 bindir=${topdir}/build/bin
@@ -27,9 +27,9 @@ if [ "$use_root" = "yes" ]; then
 fi
 
 cflags="${root_cflags} -std=${cxx_std} -I${incdir}"
-libs="-L${libdir} -lfaint ${root_libs}"
+libs="-L${libdir} -lrarexsec ${root_libs}"
 
-usage="Usage: faint-config [--bindir] [--cflags] [--cxx-std] [--datadir] \
+usage="Usage: rarexsec-config [--bindir] [--cflags] [--cxx-std] [--datadir] \
 [--libs] [--libdir] [--incdir] [--srcdir] [--topdir] [--use-root] \
 [--version] [--git-revision] [--help]"
 

--- a/rarexsec-root.sh
+++ b/rarexsec-root.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
-# Determine topdir from FAINT or script path
-if [ -z "$FAINT" ]; then
+# Determine topdir from RAREXSEC or script path
+if [ -z "$RAREXSEC" ]; then
   TOPDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 else
-  TOPDIR="$FAINT"
+  TOPDIR="$RAREXSEC"
 fi
 
 LIBDIR="${TOPDIR}/build/lib"
 INCDIR="${TOPDIR}/include"
-MACRO="${TOPDIR}/scripts/setup_faint.C"
+MACRO="${TOPDIR}/setup_rarexsec.C"
 
 # Allow users to provide an external nlohmann/json install via common
 # environment variables.  ROOT needs the headers to be discoverable at
@@ -37,4 +37,4 @@ else
 fi
 
 # Start ROOT, ensure the helper macro is loaded, then forward any user macro call
-root -l -q -e "gROOT->LoadMacro(\"${MACRO}\"); setup_faint(\"${LIBDIR}/libfaint.${LIBEXT}\",\"${INCDIR}\");" "$@"
+root -l -q -e "gROOT->LoadMacro(\"${MACRO}\"); setup_rarexsec(\"${LIBDIR}/librarexsec.${LIBEXT}\",\"${INCDIR}\");" "$@"

--- a/setup_rarexsec.C
+++ b/setup_rarexsec.C
@@ -59,18 +59,18 @@ std::string parent_dir(std::string path) {
 
 std::string infer_topdir() {
   // Allow users to point to a custom installation prefix.
-  std::string from_env = get_env("FAINT");
+  std::string from_env = get_env("RAREXSEC");
   if (!from_env.empty()) {
     return from_env;
   }
-  from_env = get_env("FAINT_PREFIX");
+  from_env = get_env("RAREXSEC_PREFIX");
   if (!from_env.empty()) {
     return from_env;
   }
 
   // `Which` searches the ROOT macro path for this helper and returns the
   // absolute location if it is discoverable.
-  if (char* located = gSystem->Which(gROOT->GetMacroPath(), "setup_faint.C")) {
+  if (char* located = gSystem->Which(gROOT->GetMacroPath(), "setup_rarexsec.C")) {
     std::string macro_path = located;
     std::free(located);
 
@@ -107,7 +107,7 @@ void load_header(const std::string& h) {
   }
 }
 
-void setup_faint(const char* abs_lib_path = nullptr, const char* abs_inc_dir = nullptr) {
+void setup_rarexsec(const char* abs_lib_path = nullptr, const char* abs_inc_dir = nullptr) {
   ErrorLevelGuard error_level_guard(kFatal);
   // Some ROOT 6 builds need libGraf preloaded for dictionaries
   if (gROOT->GetVersionInt() >= 60000) {
@@ -127,8 +127,8 @@ void setup_faint(const char* abs_lib_path = nullptr, const char* abs_inc_dir = n
   if (!include_dir.empty()) {
     gSystem->AddIncludePath( (std::string("-I") + include_dir).c_str() );
   } else {
-    std::cout << "Warning: could not determine the faint include directory. "
-              << "Pass it explicitly to setup_faint().\n";
+    std::cout << "Warning: could not determine the rarexsec include directory. "
+              << "Pass it explicitly to setup_rarexsec().\n";
   }
 
   // Load library (absolute path if given, else rely on DYLD/LD_LIBRARY_PATH)
@@ -141,9 +141,9 @@ void setup_faint(const char* abs_lib_path = nullptr, const char* abs_inc_dir = n
     rc = gSystem->Load(lib_path.c_str());
   } else {
 #ifdef __APPLE__
-    lib_path = join_path(topdir, "build/lib/libfaint.dylib");
+    lib_path = join_path(topdir, "build/lib/librarexsec.dylib");
 #else
-    lib_path = join_path(topdir, "build/lib/libfaint.so");
+    lib_path = join_path(topdir, "build/lib/librarexsec.so");
 #endif
     if (!lib_path.empty()) {
       attempted_absolute = true;
@@ -151,31 +151,31 @@ void setup_faint(const char* abs_lib_path = nullptr, const char* abs_inc_dir = n
     }
   }
   if (rc != 0 && attempted_absolute && !lib_path.empty()) {
-    std::cout << "Warning: failed to load faint library from '"
+    std::cout << "Warning: failed to load rarexsec library from '"
               << lib_path
               << "'.\n";
   }
   if (rc != 0) {
-    rc = gSystem->Load("libfaint"); // fall back to soname
+    rc = gSystem->Load("librarexsec"); // fall back to soname
   }
 
   if (rc == 0) {
-    std::cout << "Loaded faint library.\n";
+    std::cout << "Loaded rarexsec library.\n";
   } else {
     const char* env_var = gSystem->UnixPathName("/") ? "LD_LIBRARY_PATH" : "DYLD_LIBRARY_PATH";
-    std::cout << "Error loading faint library. Add its directory to "
+    std::cout << "Error loading rarexsec library. Add its directory to "
               << env_var
-              << " or pass an absolute path to setup_faint().\n";
+              << " or pass an absolute path to setup_rarexsec().\n";
   }
 
   // Pull in commonly used headers so macros can use the API immediately
   if (!include_dir.empty()) {
-    load_header("faint/Types.h");
-    load_header("faint/Samples.h");
-    load_header("faint/Selection.h");
-    load_header("faint/proc/PreSelection.h");
-    load_header("faint/proc/TruthClassifier.h");
-    load_header("faint/proc/MuonSelector.h");
-    load_header("faint/proc/Weighter.h");
+    load_header("rarexsec/Types.h");
+    load_header("rarexsec/Samples.h");
+    load_header("rarexsec/Selection.h");
+    load_header("rarexsec/proc/PreSelection.h");
+    load_header("rarexsec/proc/TruthClassifier.h");
+    load_header("rarexsec/proc/MuonSelector.h");
+    load_header("rarexsec/proc/Weighter.h");
   }
 }


### PR DESCRIPTION
## Summary
- update build and helper scripts to use rarexsec naming and environment variables
- refresh the ROOT setup macro and example to load rarexsec headers and libraries
- align documentation with the rarexsec branding and commands

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de75e55c54832e8a5e804da1bae16c