### PR TITLE
Fix Makefile directory rule indentation

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -76,7 +76,7 @@ debug: OPT:=-O0 -g
 debug: all
 
 $(OBJ) $(LIB) $(BIN):
-@mkdir -p $@
+	@mkdir -p $@
 
 $(OBJ)/%.o: $(SRC)/%.cc | $(OBJ)
 @mkdir -p $(dir $@)


### PR DESCRIPTION
## Summary
- ensure the directory creation rule in the build Makefile uses a tab-prefixed command so GNU make accepts it

## Testing
- not run (requires ROOT build environment)

------
https://chatgpt.com/codex/tasks/task_e_68dea8567094832ebc0819f016dc6ae3