### PR TITLE
Fix Makefile command indentation for build rules

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -81,18 +81,18 @@ $(OBJ) $(LIB) $(BIN):
 $(OBJ)/%.o: $(SRC)/%.cc | $(OBJ)
 	@mkdir -p $(dir $@)
 	
-$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MMD -MP -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MMD -MP -c $< -o $@
 
 $(OBJ)/%.o: $(SRC)/%.cpp | $(OBJ)
 	@mkdir -p $(dir $@)
-$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MMD -MP -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -MMD -MP -c $< -o $@
 
 $(SHARED): $(OBJS) | $(LIB)
-$(CXX) $(SHAREDFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+	$(CXX) $(SHAREDFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 	@echo Built $@
 
 $(STATIC): $(OBJS) | $(LIB)
-$(AR) rcs $@ $^
+	$(AR) rcs $@ $^
 	@echo Built $@
 
 $(CONFIG_OUT): $(CONFIG_IN) | $(BIN)


### PR DESCRIPTION
## Summary
- ensure the build rules in `build/Makefile` use tab-indented commands for compilation, linking, and archiving so GNU make can parse them correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deb0c1a270832e8322de4ae0bc64b0