### PR TITLE
Handle optional Hub data nodes

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -23,7 +24,9 @@ inline origin origin_from(const std::string& s) {
 
 struct Data {
     std::shared_ptr<ROOT::RDataFrame> df;
-    ROOT::RDF::RNode node;
+    std::optional<ROOT::RDF::RNode> node;
+
+    const ROOT::RDF::RNode& rnode() const { return node.value(); }
 };
 
 struct Entry {
@@ -37,7 +40,7 @@ struct Entry {
     double trig_eff = 0.0;
     Data nominal;
     std::unordered_map<std::string, Data> detvars;
-    const ROOT::RDF::RNode& rnode() const { return nominal.node; }
+    const ROOT::RDF::RNode& rnode() const { return nominal.rnode(); }
     const Data* detvar(const std::string& tag) const {
         auto it = detvars.find(tag);
         return it == detvars.end() ? nullptr : &it->second;

--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -65,7 +65,10 @@ void example_macro() {
       std::cout << "  Final selection entries: " << eval_final_count << std::endl;
 
       for (const auto& detvar : entry->detvars) {
-        auto detvar_count = detvar.second.node.Count().GetValue();
+        if (!detvar.second.node) {
+          continue;
+        }
+        auto detvar_count = detvar.second.rnode().Count().GetValue();
         std::cout << "  Detector variation '" << detvar.first
                   << "' entries: " << detvar_count << std::endl;
       }

--- a/src/Hub.cc
+++ b/src/Hub.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <fstream>
 #include <stdexcept>
+#include <utility>
 
 #include "rarexsec/Processor.hh"
 
@@ -17,7 +18,7 @@ rarexsec::Data rarexsec::Hub::sample(const Entry& rec) {
     if (rec.kind == sample::origin::beam) node = node.Filter("!is_strange");
     else if (rec.kind == sample::origin::strangeness) node = node.Filter("is_strange");
 
-    return Data{df_ptr, node};
+    return Data{df_ptr, std::move(node)};
 }
 
 rarexsec::Hub::Hub(const std::string& path) {


### PR DESCRIPTION
## Summary
- wrap `rarexsec::Data` nodes in `std::optional` so entries can be default constructed
- update the Hub sampler and example macro to work with the optional RNode handles

## Testing
- make -C build *(fails: root-config not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68deb33adcac832e8d37cb7693fa5ebe