### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore build artifacts and intermediate files
+build/
+*.o
+*.so
+*.dylib
+*.a
+*.out


### PR DESCRIPTION
## Summary
- add a repository-level .gitignore to filter out build directories and compiled artifacts

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68deb3c4c59c832eab51384a1d5f7cdf