### PR TITLE
Ensure rarexsec-root.sh is executable during install

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -113,7 +113,8 @@ install: all
 	@cp -a $(LIB)/* $(INSTALL_LIB)/
 	@rsync -a --delete $(INC)/ $(INSTALL_INC)/
 	@cp -a $(CONFIG_OUT) $(INSTALL_BIN)/
-	@[ -f $(TOP)/rarexsec-root.sh ] && cp -a $(TOP)/rarexsec-root.sh $(INSTALL_BIN)/rarexsec-root || true
+        @[ -f $(TOP)/rarexsec-root.sh ] && chmod +x $(TOP)/rarexsec-root.sh || true
+        @[ -f $(TOP)/rarexsec-root.sh ] && cp -a $(TOP)/rarexsec-root.sh $(INSTALL_BIN)/rarexsec-root || true
 	@[ -f $(TOP)/setup_rarexsec.C ] && cp -a $(TOP)/setup_rarexsec.C $(INSTALL_SCRIPTS)/ || true
 	@echo Installed to $(PREFIX)
 


### PR DESCRIPTION
## Summary
- ensure the install target marks rarexsec-root.sh as executable before copying it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb6c9aaa8832eabc8d6bee9183282