### PR TITLE
Align FiducialVolume header with project style

### DIFF
--- a/include/rarexsec/FiducialVolume.hh
+++ b/include/rarexsec/FiducialVolume.hh
@@ -1,18 +1,17 @@
-s#ifndef RAREXSEC_FIDUCIALVOLUME_HH
-#define RAREXSEC_FIDUCIALVOLUME_HH
+#pragma once
 
 namespace rarexsec {
 namespace fiducial {
 
-inline constexpr float kMinX = 5.f;
-inline constexpr float kMaxX = 251.f;
-inline constexpr float kMinY = -110.f;
-inline constexpr float kMaxY = 110.f;
-inline constexpr float kMinZ = 20.f;
-inline constexpr float kMaxZ = 986.f;
+inline constexpr float min_x = 5.f;
+inline constexpr float max_x = 251.f;
+inline constexpr float min_y = -110.f;
+inline constexpr float max_y = 110.f;
+inline constexpr float min_z = 20.f;
+inline constexpr float max_z = 986.f;
 
-inline constexpr float kRecoGapMinZ = 675.f;
-inline constexpr float kRecoGapMaxZ = 775.f;
+inline constexpr float reco_gap_min_z = 675.f;
+inline constexpr float reco_gap_max_z = 775.f;
 
 namespace detail {
 
@@ -23,9 +22,9 @@ inline bool is_within(const T& value, float low, float high) {
 
 template <typename X, typename Y, typename Z>
 inline bool is_in_active_volume(const X& x, const Y& y, const Z& z) {
-    return is_within(x, kMinX, kMaxX) &&
-           is_within(y, kMinY, kMaxY) &&
-           is_within(z, kMinZ, kMaxZ);
+    return is_within(x, min_x, max_x) &&
+           is_within(y, min_y, max_y) &&
+           is_within(z, min_z, max_z);
 }
 
 } // namespace detail
@@ -38,10 +37,8 @@ inline bool is_in_truth_volume(const X& x, const Y& y, const Z& z) {
 template <typename X, typename Y, typename Z>
 inline bool is_in_reco_volume(const X& x, const Y& y, const Z& z) {
     return detail::is_in_active_volume(x, y, z) &&
-           (z < kRecoGapMinZ || z > kRecoGapMaxZ);
+           (z < reco_gap_min_z || z > reco_gap_max_z);
 }
 
 } // namespace fiducial
 } // namespace rarexsec
-
-#endif 


### PR DESCRIPTION
## Summary
- replace the include guard with `#pragma once` to match other headers
- rename fiducial volume constants to snake_case and clean up formatting for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb8f4bec0832eac6c124b4d66ced7