### PR TITLE
Include fiducial volume helpers in Processor

### DIFF
--- a/src/Processor.cc
+++ b/src/Processor.cc
@@ -1,5 +1,6 @@
 #include "rarexsec/Processor.hh"
 #include "rarexsec/Hub.hh"
+#include "rarexsec/FiducialVolume.hh"
 #include <cmath>
 
 ROOT::RDF::RNode rarexsec::Processor::run(ROOT::RDF::RNode node, const rarexsec::Entry& rec) const {


### PR DESCRIPTION
## Summary
- include the fiducial volume utilities in Processor.cc so the fiducial checks compile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68debd1b7ab4832eb05c6214c6ba5ee5