### PR TITLE
Add setup macro for ROOT environment

### DIFF
--- a/setup_rarexsec.C
+++ b/setup_rarexsec.C
@@ -1,0 +1,16 @@
+#include "TInterpreter.h"
+#include "TSystem.h"
+#include "TError.h"
+
+void setup_rarexsec(const char* libpath, const char* incdir) {
+  if (libpath && libpath[0] != '\0') {
+    const Int_t loadStatus = gSystem->Load(libpath);
+    if (loadStatus < 0) {
+      ::Error("setup_rarexsec", "Failed to load library '%s' (status %d)", libpath, loadStatus);
+    }
+  }
+
+  if (incdir && incdir[0] != '\0') {
+    gInterpreter->AddIncludePath(incdir);
+  }
+}


### PR DESCRIPTION
## Summary
- add the missing `setup_rarexsec.C` helper macro expected by the wrapper script
- load the compiled library and add the include directory within the macro for ROOT macros

## Testing
- not run (ROOT is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68debdbfdfe8832e91178864f37b2aa0