### PR TITLE
Clarify trigger bookkeeping field names

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -34,10 +34,10 @@ struct Entry {
     std::string period;
     sample::origin kind = sample::origin::unknown;
     std::string file;
-    double pot      = 0.0;
-    double pot_eff  = 0.0;
-    double trig     = 0.0;
-    double trig_eff = 0.0;
+    double pot_nom  = 0.0;
+    double pot_eqv  = 0.0;
+    double trig_nom = 0.0;
+    double trig_eqv = 0.0;
     Data nominal;
     std::unordered_map<std::string, Data> detvars;
     const ROOT::RDF::RNode& rnode() const { return nominal.rnode(); }

--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -47,10 +47,10 @@ void example_macro() {
             }
         };
 
-        double total_pot = 0.0;
-        double total_pot_eff = 0.0;
-        double total_triggers = 0.0;
-        double total_triggers_eff = 0.0;
+        double total_pot_nom = 0.0;
+        double total_pot_eqv = 0.0;
+        double total_trig_nom = 0.0;
+        double total_trig_eqv = 0.0;
 
         for (const auto* entry : samples) {
             if (!entry) {
@@ -73,16 +73,16 @@ void example_macro() {
                           << "' entries: " << detvar_count << std::endl;
             }
 
-            total_pot += entry->pot;
-            total_pot_eff += (entry->pot_eff > 0.0) ? entry->pot_eff : entry->pot;
-            total_triggers += entry->trig;
-            total_triggers_eff += (entry->trig_eff > 0.0) ? entry->trig_eff : entry->trig;
+            total_pot_nom += entry->pot_nom;
+            total_pot_eqv += (entry->pot_eqv > 0.0) ? entry->pot_eqv : entry->pot_nom;
+            total_trig_nom += entry->trig_nom;
+            total_trig_eqv += (entry->trig_eqv > 0.0) ? entry->trig_eqv : entry->trig_nom;
         }
 
-        std::cout << "Total POT (nominal): " << total_pot << std::endl;
-        std::cout << "Total POT (effective): " << total_pot_eff << std::endl;
-        std::cout << "Total triggers (nominal): " << total_triggers << std::endl;
-        std::cout << "Total triggers (effective): " << total_triggers_eff << std::endl;
+        std::cout << "Total POT (nominal): " << total_pot_nom << std::endl;
+        std::cout << "Total POT (equivalent): " << total_pot_eqv << std::endl;
+        std::cout << "Total triggers (nominal): " << total_trig_nom << std::endl;
+        std::cout << "Total triggers (equivalent): " << total_trig_eqv << std::endl;
     } catch (const std::exception& ex) {
         std::cerr << "Error: " << ex.what() << std::endl;
     }

--- a/src/Hub.cc
+++ b/src/Hub.cc
@@ -43,10 +43,10 @@ rarexsec::Hub::Hub(const std::string& path) {
                 rec.kind     = sample::origin_from(s.at("kind").get<std::string>());
                 rec.file     = s.at("file").get<std::string>();
                 
-                rec.pot      = s.value("pot", 0.0);
-                rec.pot_eff  = s.value("pot_eff", 0.0);
-                rec.trig     = s.value("trig", 0.0);
-                rec.trig_eff = s.value("trig_eff", 0.0);
+                rec.pot_nom  = s.value("pot", 0.0);
+                rec.pot_eqv  = s.value("pot_eff", 0.0);
+                rec.trig_nom = s.value("trig", 0.0);
+                rec.trig_eqv = s.value("trig_eff", 0.0);
 
                 rec.nominal = sample(rec);
 

--- a/src/Processor.cc
+++ b/src/Processor.cc
@@ -12,12 +12,12 @@ ROOT::RDF::RNode rarexsec::Processor::run(ROOT::RDF::RNode node, const rarexsec:
     node = node.Define("is_ext",          [is_ext]{ return is_ext; }); 
 
     double scale_mc  = 1.0;
-    if (is_mc && rec.pot > 0.0 && rec.pot_eff > 0.0) 
-        scale_mc = rec.pot_eff / rec.pot;                  
+    if (is_mc && rec.pot_nom > 0.0 && rec.pot_eqv > 0.0)
+        scale_mc = rec.pot_eqv / rec.pot_nom;
 
     double scale_ext = 1.0;
-    if (is_ext && rec.trig > 0.0 && rec.trig_eff > 0.0) 
-        scale_ext = rec.trig_eff / rec.trig;            
+    if (is_ext && rec.trig_nom > 0.0 && rec.trig_eqv > 0.0)
+        scale_ext = rec.trig_eqv / rec.trig_nom;
 
     node = node.Define("w_base", [is_mc, is_ext, scale_mc, scale_ext] {
         return is_mc ? scale_mc : (is_ext ? scale_ext : 1.0); 


### PR DESCRIPTION
## Summary
- rename the trigger bookkeeping fields to `trig_nom` and `trig_eqv` for consistency with POT naming
- update processor scaling and the example macro to use the renamed fields and report equivalent trigger totals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debd67f3cc832eb3026f9b6342d0a4