### PR TITLE
Ensure setup script uses consistent indentation

### DIFF
--- a/setup_rarexsec.C
+++ b/setup_rarexsec.C
@@ -3,14 +3,14 @@
 #include "TError.h"
 
 void setup_rarexsec(const char* libpath, const char* incdir) {
-  if (libpath && libpath[0] != '\0') {
-    const Int_t loadStatus = gSystem->Load(libpath);
-    if (loadStatus < 0) {
-      ::Error("setup_rarexsec", "Failed to load library '%s' (status %d)", libpath, loadStatus);
+    if (libpath && libpath[0] != '\0') {
+        const Int_t loadStatus = gSystem->Load(libpath);
+        if (loadStatus < 0) {
+            ::Error("setup_rarexsec", "Failed to load library '%s' (status %d)", libpath, loadStatus);
+        }
     }
-  }
 
-  if (incdir && incdir[0] != '\0') {
-    gInterpreter->AddIncludePath(incdir);
-  }
+    if (incdir && incdir[0] != '\0') {
+        gInterpreter->AddIncludePath(incdir);
+    }
 }


### PR DESCRIPTION
## Summary
- switch setup_rarexsec.C to use 4-space indentation within the setup function

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68debeb6ea98832e889a7494052a94f6