### PR TITLE
Fix make run target to pass setup macro arguments

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -120,7 +120,7 @@ install: all
 
 run: $(SHARED)
 	@command -v root >/dev/null 2>&1 || (echo ROOT executable not found && exit 1)
-	@root -l -q -e 'gSystem->Load("$(abspath $(SHARED))"); gSystem->AddIncludePath("-I$(abspath $(INC))"); gROOT->ProcessLine(".x $(TOP)/setup_rarexsec.C$(ARGS)");'
+	@root -l -q -e 'gSystem->Load("$(abspath $(SHARED))"); gSystem->AddIncludePath("-I$(abspath $(INC))"); gROOT->ProcessLine(".x $(abspath $(TOP)/setup_rarexsec.C)(\"$(abspath $(SHARED))\",\"$(abspath $(INC))\")");'
 
 print:
 	@echo CXX=$(CXX)


### PR DESCRIPTION
## Summary
- update the `make run` recipe to invoke `setup_rarexsec.C` with the required library and include paths

## Testing
- make -C build run (fails: `root-config` not found in PATH)


------
https://chatgpt.com/codex/tasks/task_e_68debe544068832e9dcfe711d1c72a5a