### PR TITLE
Add default column definitions for non-MC samples

### DIFF
--- a/src/Processor.cc
+++ b/src/Processor.cc
@@ -101,7 +101,16 @@ ROOT::RDF::RNode rarexsec::Processor::run(ROOT::RDF::RNode node, const rarexsec:
                 return is_sig && purity > 0.5f && completeness > 0.1f;
             },
             {"is_signal", "neutrino_purity_from_pfp", "neutrino_completeness_from_pfp"});
-    } 
+    } else {
+        const int nonmc_channel = is_data ? 0 : (is_ext ? 1 : 99);
+        node = node.Define("in_fiducial", [] { return false; });
+        node = node.Define("is_strange", [] { return false; });
+        node = node.Define("interation_mode", [] { return -1; });
+        node = node.Define("analysis_channels", [nonmc_channel] { return nonmc_channel; });
+        node = node.Define("channel_definitions", [](int ch){ return ch; }, {"analysis_channels"});
+        node = node.Define("is_signal", [] { return false; });
+        node = node.Define("recognised_signal", [] { return false; });
+    }
 
     return node;
 }


### PR DESCRIPTION
## Summary
- add default column definitions for non-MC datasets to match downstream expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debf2a0550832e8cf8364fcd56881c