### PR TITLE
Run example macro in make run and relax RNode constness

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -120,7 +120,7 @@ install: all
 
 run: $(SHARED)
 	@command -v root >/dev/null 2>&1 || (echo ROOT executable not found && exit 1)
-	@root -l -q -e 'gSystem->Load("$(abspath $(SHARED))"); gSystem->AddIncludePath("-I$(abspath $(INC))"); gROOT->ProcessLine(".x $(abspath $(TOP)/setup_rarexsec.C)(\"$(abspath $(SHARED))\",\"$(abspath $(INC))\")");'
+	@$(TOP)/rarexsec-root.sh $(TOP)/macros/example_macro.C
 
 print:
 	@echo CXX=$(CXX)

--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -26,7 +26,7 @@ struct Data {
     std::shared_ptr<ROOT::RDataFrame> df;
     std::optional<ROOT::RDF::RNode> node;
 
-    const ROOT::RDF::RNode& rnode() const { return node.value(); }
+    ROOT::RDF::RNode rnode() const { return ROOT::RDF::RNode{node.value()}; }
 };
 
 struct Entry {
@@ -40,7 +40,7 @@ struct Entry {
     double trig_eqv = 0.0;
     Data nominal;
     std::unordered_map<std::string, Data> detvars;
-    const ROOT::RDF::RNode& rnode() const { return nominal.rnode(); }
+    ROOT::RDF::RNode rnode() const { return nominal.rnode(); }
     const Data* detvar(const std::string& tag) const {
         auto it = detvars.find(tag);
         return it == detvars.end() ? nullptr : &it->second;


### PR DESCRIPTION
## Summary
- return modifiable ROOT::RDF::RNode copies from Hub data accessors so the example macro can call ROOT actions
- have the make run target execute the bundled rarexsec-root.sh helper on macros/example_macro.C

## Testing
- make run *(fails: root-config not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68dec11d9e3c832e9b69c71853a2dabb