### PR TITLE
Fix example macro library loading failure

### DIFF
--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -12,8 +12,9 @@ void example_macro() {
     try {
         ROOT::EnableImplicitMT();
 
-        if (gSystem->Load("librarexsec_root")) {
-            throw std::runtime_error("Failed to load librarexsec_root library");
+        const int load_status = gSystem->Load("librarexsec");
+        if (load_status < 0) {
+            throw std::runtime_error("Failed to load librarexsec library");
         }
 
         const std::string config_path = "data/samples.json";


### PR DESCRIPTION
## Summary
- load the librexsec library in the example macro and treat negative load statuses as failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec1f03810832e840496b5e9a31280