### PR TITLE
Handle float spline weights in Processor

### DIFF
--- a/src/Processor.cc
+++ b/src/Processor.cc
@@ -29,8 +29,8 @@ ROOT::RDF::RNode rarexsec::Processor::run(ROOT::RDF::RNode node, const rarexsec:
     if (is_mc) {
         node = node.Define(
             "w_nominal",
-            [](double w, double w_spline, double w_tune) {
-                double out = w * w_spline * w_tune;
+            [](double w, const auto& w_spline, const auto& w_tune) {
+                double out = w * static_cast<double>(w_spline) * static_cast<double>(w_tune);
                 if (!std::isfinite(out) || out < 0.0) return 1.0;
                 return out;
             },


### PR DESCRIPTION
## Summary
- adjust the nominal weight calculation lambda to accept spline weights with their native types
- cast spline and tune weights to double before combining them with the base weight

## Testing
- ./rarexsec-root.sh macros/example_macro.C *(fails: root executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ded8e93d74832eab78fc2f802afbda