### PR TITLE
Refactor Selection constants

### DIFF
--- a/include/rarexsec/Selection.hh
+++ b/include/rarexsec/Selection.hh
@@ -10,39 +10,39 @@ namespace rarexsec {
 namespace selection {
 
 namespace column {
-    inline constexpr const char* pass_pre = "pass_pre";
-    inline constexpr const char* pass_flash = "pass_flash";
-    inline constexpr const char* pass_fiducial = "pass_fv";
-    inline constexpr const char* pass_muon = "pass_mu";
-    inline constexpr const char* pass_topology = "pass_topo";
-    inline constexpr const char* pass_final = "pass_final";
-    inline constexpr const char* quality_event = "quality_event";
-    inline constexpr const char* nominal_weight = "nominal_event_weight";
+inline constexpr const char* pass_pre = "pass_pre";
+inline constexpr const char* pass_flash = "pass_flash";
+inline constexpr const char* pass_fiducial = "pass_fv";
+inline constexpr const char* pass_muon = "pass_mu";
+inline constexpr const char* pass_topology = "pass_topo";
+inline constexpr const char* pass_final = "pass_final";
+inline constexpr const char* quality_event = "quality_event";
+inline constexpr const char* nominal_weight = "nominal_event_weight";
 }
 
-struct PreCut {
-    static constexpr float min_beam_pe = 0.f;
-    static constexpr float max_veto_pe = 20.f;
-};
+namespace pre {
+inline constexpr float min_beam_pe = 0.f;
+inline constexpr float max_veto_pe = 20.f;
+}
 
-struct FlashCut {
-    static constexpr int required_slices = 1;
-    static constexpr float min_topological_score = 0.06f;
-    static constexpr int min_generation2_pfps = 2;
-};
+namespace flash {
+inline constexpr int required_slices = 1;
+inline constexpr float min_topological_score = 0.06f;
+inline constexpr int min_generation2_pfps = 2;
+}
 
-struct TopologyCut {
-    static constexpr float min_contained_fraction = 0.7f;
-    static constexpr float min_cluster_fraction = 0.5f;
-};
+namespace topology {
+inline constexpr float min_contained_fraction = 0.7f;
+inline constexpr float min_cluster_fraction = 0.5f;
+}
 
-struct MuonTrackCut {
-    static constexpr float min_score = 0.5f;
-    static constexpr float min_llr = 0.2f;
-    static constexpr float min_length = 10.0f;
-    static constexpr float max_distance = 4.0f;
-    static constexpr unsigned required_generation = 2u;
-};
+namespace muon_track {
+inline constexpr float min_score = 0.5f;
+inline constexpr float min_llr = 0.2f;
+inline constexpr float min_length = 10.0f;
+inline constexpr float max_distance = 4.0f;
+inline constexpr unsigned required_generation = 2u;
+}
 
 inline bool passes_pre_selection(sample::origin origin, float pe_beam,
                                  float pe_veto, bool software_trigger) {
@@ -50,17 +50,17 @@ inline bool passes_pre_selection(sample::origin origin, float pe_beam,
         (origin == sample::origin::beam || origin == sample::origin::strangeness ||
          origin == sample::origin::dirt);
     const bool dataset_gate = requires_dataset_gate
-                                  ? (pe_beam > PreCut::min_beam_pe &&
-                                     pe_veto < PreCut::max_veto_pe)
+                                  ? (pe_beam > pre::min_beam_pe &&
+                                     pe_veto < pre::max_veto_pe)
                                   : true;
     return dataset_gate && software_trigger;
 }
 
 inline bool passes_flash_selection(int num_slices, float topological_score,
                                    int generation2_pfps) {
-    return num_slices == FlashCut::required_slices &&
-           topological_score > FlashCut::min_topological_score &&
-           generation2_pfps >= FlashCut::min_generation2_pfps;
+    return num_slices == flash::required_slices &&
+           topological_score > flash::min_topological_score &&
+           generation2_pfps >= flash::min_generation2_pfps;
 }
 
 inline bool in_reco_fiducial_volume(float x, float y, float z) {
@@ -73,17 +73,17 @@ inline bool passes_muon_selection(std::size_t n_muons) {
 
 inline bool passes_topology_selection(float contained_fraction,
                                       float cluster_fraction) {
-    return contained_fraction >= TopologyCut::min_contained_fraction &&
-           cluster_fraction >= TopologyCut::min_cluster_fraction;
+    return contained_fraction >= topology::min_contained_fraction &&
+           cluster_fraction >= topology::min_cluster_fraction;
 }
 
 inline bool passes_muon_track_selection(float score, float llr, float length,
                                         float distance, unsigned generation) {
-    return score > MuonTrackCut::min_score &&
-           llr > MuonTrackCut::min_llr &&
-           length > MuonTrackCut::min_length &&
-           distance < MuonTrackCut::max_distance &&
-           generation == MuonTrackCut::required_generation;
+    return score > muon_track::min_score &&
+           llr > muon_track::min_llr &&
+           length > muon_track::min_length &&
+           distance < muon_track::max_distance &&
+           generation == muon_track::required_generation;
 }
 
 inline bool passes_final_selection(bool pre, bool flash, bool fiducial,


### PR DESCRIPTION
## Summary
- refactor selection cut constants into namespaced inline constexpr declarations to align with other headers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dedc634564832eaa228047de3ed8ed