### PR TITLE
Remove ntupledir metadata from sample catalogue

### DIFF
--- a/data/samples.json
+++ b/data/samples.json
@@ -1,5 +1,4 @@
 {
-  "ntupledir": "/exp/uboone/data/users/nlane/ntuples",
   "beamlines": {
     "numi-fhc": {
       "run1": {

--- a/data/tools/build-catalogue.py
+++ b/data/tools/build-catalogue.py
@@ -486,7 +486,6 @@ def main() -> None:
     outdir.mkdir(parents=True, exist_ok=True)
     out_path = outdir / "samples.json"
     catalogue = {
-        "ntupledir": str(ntuple_dir),
         "beamlines": beamlines_out,
     }
     with open(out_path, "w") as f:


### PR DESCRIPTION
## Summary
- drop the ntupledir field when generating catalogues
- remove the unused ntupledir entry from the checked-in samples.json

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dedf0f8728832ea2de4d67c476dbfb