### PR TITLE
Format snapshot components with repo style

### DIFF
--- a/include/rarexsec/Snapshot.hh
+++ b/include/rarexsec/Snapshot.hh
@@ -11,19 +11,18 @@ class Hub;
 namespace snapshot {
 
 struct Options {
-  std::string outdir = "snapshots";
-  std::string tree   = "analysis";
-  std::vector<std::string> columns; 
+    std::string outdir = "snapshots";
+    std::string tree = "analysis";
+    std::vector<std::string> columns;
 };
 
-std::vector<std::string>
-write(const std::vector<const Entry*>& samples, const Options& opt = {});
+std::vector<std::string> write(const std::vector<const Entry*>& samples,
+                               const Options& opt = {});
 
-std::vector<std::string>
-write(const Hub& hub,
-      std::string_view beamline,
-      const std::vector<std::string>& periods,
-      const Options& opt = {});
+std::vector<std::string> write(const Hub& hub,
+                               std::string_view beamline,
+                               const std::vector<std::string>& periods,
+                               const Options& opt = {});
 
-} 
-} 
+}
+}

--- a/src/Snapshot.cc
+++ b/src/Snapshot.cc
@@ -17,97 +17,111 @@ namespace rarexsec {
 namespace snapshot {
 
 static std::string origin_to_string(sample::origin k) {
-  switch (k) {
-    case sample::origin::data:        return "data";
-    case sample::origin::beam:        return "beam";
-    case sample::origin::strangeness: return "strangeness";
-    case sample::origin::ext:         return "ext";
-    case sample::origin::dirt:        return "dirt";
-    default:                          return "unknown";
-  }
+    switch (k) {
+        case sample::origin::data:
+            return "data";
+        case sample::origin::beam:
+            return "beam";
+        case sample::origin::strangeness:
+            return "strangeness";
+        case sample::origin::ext:
+            return "ext";
+        case sample::origin::dirt:
+            return "dirt";
+        default:
+            return "unknown";
+    }
 }
 
 static std::string sanitise(std::string s) {
-  for (char& c : s) {
-    if (!(std::isalnum(static_cast<unsigned char>(c)) || c=='-' || c=='_' || c=='.'))
-      c = '_';
-  }
-  return s;
+    for (char& c : s) {
+        if (!(std::isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_' || c == '.'))
+            c = '_';
+    }
+    return s;
 }
 
 static const std::vector<std::string>& default_columns() {
-  static const std::vector<std::string> cols{
-    "run", "subrun", "event",
-    "w_nominal",
-    "analysis_channels",
-  };
-  return cols;
+    static const std::vector<std::string> cols{
+        "run", "subrun", "event",
+        "w_nominal",
+        "analysis_channels",
+    };
+    return cols;
 }
 
-static std::vector<std::string> intersect_cols(const ROOT::RDF::RNode& node, const std::vector<std::string>& wanted) {
-  auto have = node.GetColumnNames();
-  std::unordered_set<std::string> avail(have.begin(), have.end());
-  const auto& req = wanted.empty() ? default_columns() : wanted;
+static std::vector<std::string> intersect_cols(const ROOT::RDF::RNode& node,
+                                               const std::vector<std::string>& wanted) {
+    auto have = node.GetColumnNames();
+    std::unordered_set<std::string> avail(have.begin(), have.end());
+    const auto& req = wanted.empty() ? default_columns() : wanted;
 
-  std::vector<std::string> out;
-  out.reserve(req.size());
-  for (const auto& c : req) if (avail.count(c)) out.push_back(c);
-  return out;
+    std::vector<std::string> out;
+    out.reserve(req.size());
+    for (const auto& c : req) {
+        if (avail.count(c))
+            out.push_back(c);
+    }
+    return out;
 }
 
 static std::string make_out_path(const Options& opt,
                                  const Entry& e,
                                  const std::string& detvar_tag) {
-  const auto base = fs::path(e.file).filename().string();
-  std::string name = sanitise(e.beamline) + "_" +
-                     sanitise(e.period)   + "_" +
-                     sanitise(origin_to_string(e.kind));
-  if (!detvar_tag.empty()) {
-    name += "__" + sanitise(detvar_tag);
-  }
-  name += "__" + sanitise(base);
-  if (!name.ends_with(".root")) name += ".root";
+    const auto base = fs::path(e.file).filename().string();
+    std::string name = sanitise(e.beamline) + "_" +
+                       sanitise(e.period) + "_" +
+                       sanitise(origin_to_string(e.kind));
+    if (!detvar_tag.empty()) {
+        name += "__" + sanitise(detvar_tag);
+    }
+    name += "__" + sanitise(base);
+    if (!name.ends_with(".root"))
+        name += ".root";
 
-  fs::create_directories(opt.outdir);
-  return (fs::path(opt.outdir) / name).string();
+    fs::create_directories(opt.outdir);
+    return (fs::path(opt.outdir) / name).string();
 }
 
-std::vector<std::string>write(const std::vector<const Entry*>& samples, const Options& opt) {
-  std::vector<std::string> outputs;
-  outputs.reserve(samples.size());
+std::vector<std::string> write(const std::vector<const Entry*>& samples,
+                               const Options& opt) {
+    std::vector<std::string> outputs;
+    outputs.reserve(samples.size());
 
-  for (const Entry* e : samples) {
-    if (!e) continue;
+    for (const Entry* e : samples) {
+        if (!e)
+            continue;
 
-    {
-      const auto cols = intersect_cols(e->rnode(), opt.columns);
-      const auto out  = make_out_path(opt, *e, /*detvar*/"");
-      e->rnode().Snapshot(opt.tree, out, cols).GetValue(); 
-      outputs.push_back(out);
+        {
+            const auto cols = intersect_cols(e->rnode(), opt.columns);
+            const auto out = make_out_path(opt, *e, /*detvar*/ "");
+            e->rnode().Snapshot(opt.tree, out, cols).GetValue();
+            outputs.push_back(out);
+        }
+
+        for (const auto& kv : e->detvars) {
+            const auto& tag = kv.first;
+            const auto& dv = kv.second;
+            if (!dv.node)
+                continue;
+
+            const auto cols = intersect_cols(dv.rnode(), opt.columns);
+            const auto out = make_out_path(opt, *e, tag);
+            dv.rnode().Snapshot(opt.tree, out, cols).GetValue();
+            outputs.push_back(out);
+        }
     }
 
-    for (const auto& kv : e->detvars) {
-      const auto& tag = kv.first;
-      const auto& dv  = kv.second;
-      if (!dv.node) continue;
-
-      const auto cols = intersect_cols(dv.rnode(), opt.columns);
-      const auto out  = make_out_path(opt, *e, tag);
-      dv.rnode().Snapshot(opt.tree, out, cols).GetValue(); 
-      outputs.push_back(out);
-    }
-  }
-
-  return outputs;
+    return outputs;
 }
 
 std::vector<std::string> write(const Hub& hub,
-                                std::string_view beamline,
-                                const std::vector<std::string>& periods,
-                                const Options& opt) {
-  auto sims = hub.simulation(std::string(beamline), periods); 
-  return write(sims, opt);
+                               std::string_view beamline,
+                               const std::vector<std::string>& periods,
+                               const Options& opt) {
+    auto sims = hub.simulation(std::string(beamline), periods);
+    return write(sims, opt);
 }
 
-} 
-} 
+}
+}


### PR DESCRIPTION
## Summary
- restyle `Snapshot.hh` to use four-space indentation and align function declarations with repository conventions
- reformat `Snapshot.cc` to match the project's indentation and brace style

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68def18df50c832eaf125ca1699f97e5