### PR TITLE
Remove Preset to_string helper

### DIFF
--- a/include/rarexsec/Selection.hh
+++ b/include/rarexsec/Selection.hh
@@ -85,20 +85,6 @@ enum class Preset {
     Final
 };
 
-inline const char* to_string(Preset p) {
-    switch (p) {
-        case Preset::All: return "All";
-        case Preset::FiducialOnly: return "FiducialOnly";
-        case Preset::MuonOnly: return "MuonOnly";
-        case Preset::Baseline: return "Baseline";
-        case Preset::PreOnly: return "PreOnly";
-        case Preset::FlashOnly: return "FlashOnly";
-        case Preset::TopologyOnly: return "TopologyOnly";
-        case Preset::Final: return "Final";
-        default: return "Unknown";
-    }
-}
-
 inline ROOT::RDF::RNode apply(ROOT::RDF::RNode node, Preset p, const rarexsec::Entry& rec) {
     switch (p) {
         case Preset::All:


### PR DESCRIPTION
## Summary
- remove the obsolete `Preset` string conversion helper from `Selection.hh`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def84c7088832ebeff3e5463244e64