### PR TITLE
Rename Data structure to Frame

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -22,7 +22,7 @@ inline origin origin_from(const std::string& s) {
 }
 }
 
-struct Data {
+struct Frame {
     std::shared_ptr<ROOT::RDataFrame> df;
     std::optional<ROOT::RDF::RNode> node;
 
@@ -38,10 +38,10 @@ struct Entry {
     double pot_eqv  = 0.0;
     double trig_nom = 0.0;
     double trig_eqv = 0.0;
-    Data nominal;
-    std::unordered_map<std::string, Data> detvars;
+    Frame nominal;
+    std::unordered_map<std::string, Frame> detvars;
     ROOT::RDF::RNode rnode() const { return nominal.rnode(); }
-    const Data* detvar(const std::string& tag) const {
+    const Frame* detvar(const std::string& tag) const {
         auto it = detvars.find(tag);
         return it == detvars.end() ? nullptr : &it->second;
     }
@@ -60,7 +60,7 @@ private:
     using beamline_map = std::unordered_map<std::string, period_map>;
     beamline_map db_;
 
-    static Data sample(const Entry& rec);
+    static Frame sample(const Entry& rec);
 };
 
 }

--- a/install/include/rarexsec/Hub.hh
+++ b/install/include/rarexsec/Hub.hh
@@ -22,7 +22,7 @@ inline origin origin_from(const std::string& s) {
 }
 }
 
-struct Data {
+struct Frame {
     std::shared_ptr<ROOT::RDataFrame> df;
     std::optional<ROOT::RDF::RNode> node;
 
@@ -38,10 +38,10 @@ struct Entry {
     double pot_eqv  = 0.0;
     double trig_nom = 0.0;
     double trig_eqv = 0.0;
-    Data nominal;
-    std::unordered_map<std::string, Data> detvars;
+    Frame nominal;
+    std::unordered_map<std::string, Frame> detvars;
     ROOT::RDF::RNode rnode() const { return nominal.rnode(); }
-    const Data* detvar(const std::string& tag) const {
+    const Frame* detvar(const std::string& tag) const {
         auto it = detvars.find(tag);
         return it == detvars.end() ? nullptr : &it->second;
     }
@@ -60,7 +60,7 @@ private:
     using beamline_map = std::unordered_map<std::string, period_map>;
     beamline_map db_;
 
-    static Data sample(const Entry& rec);
+    static Frame sample(const Entry& rec);
 };
 
 }

--- a/src/Hub.cc
+++ b/src/Hub.cc
@@ -7,7 +7,7 @@
 
 #include "rarexsec/Processor.hh"
 
-rarexsec::Data rarexsec::Hub::sample(const Entry& rec) {
+rarexsec::Frame rarexsec::Hub::sample(const Entry& rec) {
     constexpr const char* tree = "nuselection/EventSelectionFilter";
 
     auto df_ptr = std::make_shared<ROOT::RDataFrame>(tree, rec.file);
@@ -20,7 +20,7 @@ rarexsec::Data rarexsec::Hub::sample(const Entry& rec) {
     else if (rec.kind == sample::origin::strangeness)
         node = node.Filter([](bool s){ return  s; }, {"is_strange"});
 
-    return Data{df_ptr, std::move(node)};
+    return Frame{df_ptr, std::move(node)};
 }
 
 rarexsec::Hub::Hub(const std::string& path) {


### PR DESCRIPTION
## Summary
- rename the `Data` structure to `Frame` to better reflect its contents
- update all references and factory method signatures accordingly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def98c1f84832e975bb1cf551b38fc