### PR TITLE
Evaluate muon tracks directly in selection preset

### DIFF
--- a/src/Selection.cc
+++ b/src/Selection.cc
@@ -1,0 +1,19 @@
+#include "rarexsec/Selection.hh"
+
+namespace rarexsec {
+namespace selection {
+
+bool passes_muon_track_selection(float score,
+                                 float llr,
+                                 float length,
+                                 float distance,
+                                 unsigned generation) {
+    return score > min_score &&
+           llr > min_llr &&
+           length > min_length &&
+           distance < max_distance &&
+           generation == required_generation;
+}
+
+}  // namespace selection
+}  // namespace rarexsec


### PR DESCRIPTION
## Summary
- update the muon-only selection preset to scan track variables and apply the muon track cuts within Selection.hh

## Testing
- make -C build *(fails: root-config not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68defa08c284832e89d614953e5988a9