### PR TITLE
Ensure macros load librexsec and use consistent indentation

### DIFF
--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -12,6 +12,10 @@ void example_macro() {
     try {
         ROOT::EnableImplicitMT();
 
+        if (gSystem->Load("librarexsec") < 0) {
+            throw std::runtime_error("Failed to load librexsec");
+        }
+
         const std::string config_path = "data/samples.json";
         const std::string beamline = "numi-fhc";
         const std::vector<std::string> periods = {"run1"};
@@ -27,19 +31,19 @@ void example_macro() {
 
         auto origin_to_string = [](rarexsec::sample::origin kind) {
             switch (kind) {
-                case rarexsec::sample::origin::data:
-                    return "data";
-                case rarexsec::sample::origin::beam:
-                    return "beam";
-                case rarexsec::sample::origin::strangeness:
-                    return "strangeness";
-                case rarexsec::sample::origin::ext:
-                    return "ext";
-                case rarexsec::sample::origin::dirt:
-                    return "dirt";
-                case rarexsec::sample::origin::unknown:
-                default:
-                    return "unknown";
+            case rarexsec::sample::origin::data:
+                return "data";
+            case rarexsec::sample::origin::beam:
+                return "beam";
+            case rarexsec::sample::origin::strangeness:
+                return "strangeness";
+            case rarexsec::sample::origin::ext:
+                return "ext";
+            case rarexsec::sample::origin::dirt:
+                return "dirt";
+            case rarexsec::sample::origin::unknown:
+            default:
+                return "unknown";
             }
         };
 

--- a/macros/snapshot_macro.C
+++ b/macros/snapshot_macro.C
@@ -10,33 +10,35 @@
 #include <vector>
 
 void snapshot_macro() {
-  try {
-    ROOT::EnableImplicitMT();
+    try {
+        ROOT::EnableImplicitMT();
 
-    if (gSystem->Load("librarexsec") < 0) {
-      throw std::runtime_error("Failed to load librexsec");
+        if (gSystem->Load("librarexsec") < 0) {
+            throw std::runtime_error("Failed to load librexsec");
+        }
+
+        const std::string config_path = "data/samples.json";
+        const std::string beamline = "numi-fhc";
+        const std::vector<std::string> periods = {"run1"};
+
+        rarexsec::Hub hub(config_path);
+
+        rarexsec::snapshot::Options opt;
+        opt.outdir = "snapshots";
+        opt.tree = "analysis";
+
+        auto outputs = rarexsec::snapshot::write(hub, beamline, periods, opt);
+
+        if (outputs.empty()) {
+            std::cout << "[snapshot] no files were written (no matching samples?).\n";
+        } else {
+            std::cout << "[snapshot] wrote " << outputs.size() << " file(s):\n";
+            for (const auto& f : outputs) {
+                std::cout << "  " << f << "\n";
+            }
+        }
+
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
     }
-
-    const std::string config_path = "data/samples.json";
-    const std::string beamline    = "numi-fhc";
-    const std::vector<std::string> periods = {"run1"};
-
-    rarexsec::Hub hub(config_path);
-
-    rarexsec::snapshot::Options opt;
-    opt.outdir = "snapshots";
-    opt.tree   = "analysis";
-
-    auto outputs = rarexsec::snapshot::write(hub, beamline, periods, opt);
-
-    if (outputs.empty()) {
-      std::cout << "[snapshot] no files were written (no matching samples?).\n";
-    } else {
-      std::cout << "[snapshot] wrote " << outputs.size() << " file(s):\n";
-      for (const auto& f : outputs) std::cout << "  " << f << "\n";
-    }
-
-  } catch (const std::exception& ex) {
-    std::cerr << "Error: " << ex.what() << "\n";
-  }
 }


### PR DESCRIPTION
## Summary
- load the librexsec library in `example_macro.C` so the macro evaluates successfully
- reformat `snapshot_macro.C` to use consistent 4-space indentation and brace style

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68defeafbf70832e8b1ff4471229a977