### PR TITLE
Update snapshot macro to collect samples before writing

### DIFF
--- a/macros/snapshot_macro.C
+++ b/macros/snapshot_macro.C
@@ -22,12 +22,13 @@ void snapshot_macro() {
         const std::vector<std::string> periods = {"run1"};
 
         rarexsec::Hub hub(config_path);
+        const auto samples = hub.simulation(beamline, periods);
 
         rarexsec::snapshot::Options opt;
         opt.outdir = "snapshots";
         opt.tree = "analysis";
 
-        auto outputs = rarexsec::snapshot::write(hub, beamline, periods, opt);
+        auto outputs = rarexsec::snapshot::write(samples, opt);
 
         if (outputs.empty()) {
             std::cout << "[snapshot] no files were written (no matching samples?).\n";


### PR DESCRIPTION
## Summary
- obtain the simulation samples from the hub in the snapshot macro
- call the snapshot writer overload that operates on the retrieved samples

## Testing
- not run (ROOT environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df008fa140832e8504bbe18a388dbf