### PR TITLE
Fix slice selection filter constants

### DIFF
--- a/include/rarexsec/Selection.hh
+++ b/include/rarexsec/Selection.hh
@@ -57,8 +57,8 @@ inline ROOT::RDF::RNode apply(ROOT::RDF::RNode node, Preset p, const rarexsec::E
                                {"pe_beam", "pe_veto", "software_trigger"});
         case Preset::Slice:
             return node.Filter([](int ns, float topo){
-                                   return ns == required_slices &&
-                                          topo > min_topological_score;
+                                   return ns == slice_required_count &&
+                                          topo > slice_min_topology_score;
                                },
                                {"num_slices", "topological_score"});
         case Preset::Fiducial:


### PR DESCRIPTION
## Summary
- fix the slice selection filter to use the defined constants for slice count and topology score thresholds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df066e5590832e9a14daaa53b770a9