### PR TITLE
Rename Hub::simulation to simulation_entries

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -51,8 +51,8 @@ class Hub {
 public:
     explicit Hub(const std::string& path);
 
-    std::vector<const rarexsec::Entry*> simulation(const std::string& beamline,
-                                                   const std::vector<std::string>& periods) const;
+    std::vector<const rarexsec::Entry*> simulation_entries(const std::string& beamline,
+                                                           const std::vector<std::string>& periods) const;
 
 
 private:

--- a/macros/example_macro.C
+++ b/macros/example_macro.C
@@ -21,7 +21,7 @@ void example_macro() {
         const std::vector<std::string> periods = {"run1"};
 
         rarexsec::Hub hub(config_path);
-        const auto samples = hub.simulation(beamline, periods);
+        const auto samples = hub.simulation_entries(beamline, periods);
 
         std::cout << "Loaded beamline " << beamline << " for";
         for (const auto& period : periods) {

--- a/macros/example_macro_preset.C
+++ b/macros/example_macro_preset.C
@@ -45,7 +45,7 @@ void example_macro_preset() {
 
         std::cout << "Using preset: " << preset_to_string(preset) << "\n";
 
-        const auto samples = hub.simulation(beamline, periods);
+        const auto samples = hub.simulation_entries(beamline, periods);
         std::cout << "Found " << samples.size() << " simulation samples" << std::endl;
 
         for (const auto* entry : samples) {

--- a/macros/snapshot_macro.C
+++ b/macros/snapshot_macro.C
@@ -22,7 +22,7 @@ void snapshot_macro() {
         const std::vector<std::string> periods = {"run1"};
 
         rarexsec::Hub hub(config_path);
-        const auto samples = hub.simulation(beamline, periods);
+        const auto samples = hub.simulation_entries(beamline, periods);
 
         rarexsec::snapshot::Options opt;
         opt.outdir = "snapshots";

--- a/src/Hub.cc
+++ b/src/Hub.cc
@@ -75,8 +75,8 @@ rarexsec::Hub::Hub(const std::string& path) {
     }
 }
 
-std::vector<const rarexsec::Entry*> rarexsec::Hub::simulation(const std::string& beamline,
-                                                              const std::vector<std::string>& periods) const {
+std::vector<const rarexsec::Entry*> rarexsec::Hub::simulation_entries(const std::string& beamline,
+                                                                      const std::vector<std::string>& periods) const {
     std::vector<const Entry*> out;
     auto it_bl = db_.find(beamline);
     if (it_bl == db_.end()) return out;


### PR DESCRIPTION
## Summary
- rename Hub::simulation to simulation_entries to match the requested naming
- update macro call sites to use the new method name

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df070b6204832eb36bf7f61863a331