### PR TITLE
Remove redundant forward declarations from Snapshot header

### DIFF
--- a/include/rarexsec/Snapshot.hh
+++ b/include/rarexsec/Snapshot.hh
@@ -14,9 +14,6 @@
 
 namespace rarexsec {
 
-struct Entry;
-class Hub;
-
 namespace snapshot {
 
 struct Options {


### PR DESCRIPTION
## Summary
- remove unused forward declarations for `Entry` and `Hub` in the snapshot header

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df0aad509c832e90a4f876069666bd