### PR TITLE
Remove redundant scope in snapshot helper

### DIFF
--- a/include/rarexsec/Snapshot.hh
+++ b/include/rarexsec/Snapshot.hh
@@ -104,12 +104,10 @@ inline std::vector<std::string> write(const std::vector<const Entry*>& samples,
         if (!e)
             continue;
 
-        {
-            const auto cols = detail::intersect_cols(e->rnode(), opt.columns);
-            const auto out = detail::make_out_path(opt, *e, /*detvar*/ "");
-            e->rnode().Snapshot(opt.tree, out, cols).GetValue();
-            outputs.push_back(out);
-        }
+        const auto cols = detail::intersect_cols(e->rnode(), opt.columns);
+        const auto out = detail::make_out_path(opt, *e, /*detvar*/ "");
+        e->rnode().Snapshot(opt.tree, out, cols).GetValue();
+        outputs.push_back(out);
 
         for (const auto& kv : e->detvars) {
             const auto& tag = kv.first;


### PR DESCRIPTION
## Summary
- remove an unnecessary scoped block in snapshot::write so the logic is clearer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0acc651c832e862028b65ce40106