### PR TITLE
Rename ROOT macros with descriptive names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@
 After building, the rarexsec libraries must be discoverable by ROOT.  The `rarexsec-root.sh` wrapper sets up the include and library paths and executes any macro you pass to it.  From the repository root run:
 
 ```bash
-./rarexsec-root.sh -b -q macros/example_macro.C
+./rarexsec-root.sh -b -q macros/inspect_simulation_samples.C
 ```
 
-This command loads the generated libraries, configures ROOT include paths, and runs the `example_macro()` entry point defined in `macros/example_macro.C`.
+This command loads the generated libraries, configures ROOT include paths, and runs the `inspect_simulation_samples()` entry point defined in `macros/inspect_simulation_samples.C`.
 
 Alternatively, you can call the setup macro manually from ROOT by providing the absolute library and include directories:
 
 ```bash
-root -l -q -e 'setup_rarexsec("$PWD/build/lib/librarexsec.so","$PWD/include")' macros/example_macro.C
+root -l -q -e 'setup_rarexsec("$PWD/build/lib/librarexsec.so","$PWD/include")' macros/inspect_simulation_samples.C
 ```

--- a/macros/apply_inclusive_mucc_preset.C
+++ b/macros/apply_inclusive_mucc_preset.C
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-void example_macro_preset() {
+void apply_inclusive_mucc_preset() {
     try {
         ROOT::EnableImplicitMT();
         if (gSystem->Load("librarexsec") < 0) {

--- a/macros/inspect_simulation_samples.C
+++ b/macros/inspect_simulation_samples.C
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-void example_macro() {
+void inspect_simulation_samples() {
     try {
         ROOT::EnableImplicitMT();
 

--- a/macros/write_simulation_snapshots.C
+++ b/macros/write_simulation_snapshots.C
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-void snapshot_macro() {
+void write_simulation_snapshots() {
     try {
         ROOT::EnableImplicitMT();
 


### PR DESCRIPTION
## Summary
- rename the ROOT macros to reflect what they do: inspect_simulation_samples, apply_inclusive_mucc_preset, and write_simulation_snapshots
- update the README usage instructions to reference the new macro file and entry point names

## Testing
- not run (macro rename only)


------
https://chatgpt.com/codex/tasks/task_e_68df0a65e2a4832eaabd6d5e141dcabb