### PR TITLE
Remove unused snapshot hub write declaration

### DIFF
--- a/include/rarexsec/Snapshot.hh
+++ b/include/rarexsec/Snapshot.hh
@@ -122,10 +122,5 @@ inline std::vector<std::string> write(const std::vector<const Entry*>& samples,
     return outputs;
 }
 
-std::vector<std::string> write(const Hub& hub,
-                               std::string_view beamline,
-                               const std::vector<std::string>& periods,
-                               const Options& opt = {});
-
 }
 }


### PR DESCRIPTION
## Summary
- remove the declaration of the hub-based snapshot write overload from Snapshot.hh

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df0c0b6588832e85ba35e3a5ce646f