### PR TITLE
Add data entry retrieval to Hub

### DIFF
--- a/include/rarexsec/Hub.hh
+++ b/include/rarexsec/Hub.hh
@@ -53,6 +53,8 @@ public:
 
     std::vector<const rarexsec::Entry*> simulation_entries(const std::string& beamline,
                                                            const std::vector<std::string>& periods) const;
+    std::vector<const rarexsec::Entry*> data_entries(const std::string& beamline,
+                                                    const std::vector<std::string>& periods) const;
 
 
 private:

--- a/src/Hub.cc
+++ b/src/Hub.cc
@@ -89,3 +89,17 @@ std::vector<const rarexsec::Entry*> rarexsec::Hub::simulation_entries(const std:
     }
     return out;
 }
+
+std::vector<const rarexsec::Entry*> rarexsec::Hub::data_entries(
+    const std::string& beamline, const std::vector<std::string>& periods) const {
+    std::vector<const Entry*> out;
+    auto it_bl = db_.find(beamline);
+    if (it_bl == db_.end()) return out;
+    for (const auto& per : periods) {
+        auto it_p = it_bl->second.find(per);
+        if (it_p == it_bl->second.end()) continue;
+        for (const auto& rec : it_p->second)
+            if (rec.kind == sample::origin::data) out.push_back(&rec);
+    }
+    return out;
+}


### PR DESCRIPTION
## Summary
- declare a Hub::data_entries accessor that exposes data samples for a beamline and set of periods
- implement the accessor to collect only data-origin records for the requested beamline and periods

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfadcac538832e9596ad9ff774c2c1