### PR TITLE
Reformat make_plots macro indentation

### DIFF
--- a/macros/make_plots.C
+++ b/macros/make_plots.C
@@ -5,40 +5,40 @@
 #include <stdexcept>
 
 void make_plots() {
-  ROOT::EnableImplicitMT();
-  if (gSystem->Load("librarexsec") < 0) throw std::runtime_error("Failed to load librexsec");
+    ROOT::EnableImplicitMT();
+    if (gSystem->Load("librarexsec") < 0) throw std::runtime_error("Failed to load librexsec");
 
-  const std::string config   = "data/samples.json";
-  const std::string beamline = "NuMI FHC";
-  const std::vector<std::string> periods = {"run1"};
+    const std::string config   = "data/samples.json";
+    const std::string beamline = "NuMI FHC";
+    const std::vector<std::string> periods = {"run1"};
 
-  rarexsec::Hub hub(config);
-  auto mc   = hub.simulation_entries("numi-fhc", periods);
-  auto data = hub.data_entries("numi-fhc", periods);
+    rarexsec::Hub hub(config);
+    auto mc   = hub.simulation_entries("numi-fhc", periods);
+    auto data = hub.data_entries("numi-fhc", periods);
 
-  rarexsec::plot::Plotter plotter({
-    .out_dir          = "plots/numi-fhc/run1",
-    .image_format     = "png",
-    .show_ratio       = true,
-    .use_log_y        = false,
-    .annotate_numbers = true,
-    .overlay_signal   = true,
-    .signal_channels  = {15,16}, // CC + strange
-    .y_min            = 0.,
-    .y_max            = -1.,
-    .cuts             = { /* e.g. {1.2, rarexsec::plot::CutDir::GreaterThan} */ },
-    .beamline         = beamline,
-    .periods          = periods
-  });
+    rarexsec::plot::Plotter plotter({
+        .out_dir          = "plots/numi-fhc/run1",
+        .image_format     = "png",
+        .show_ratio       = true,
+        .use_log_y        = false,
+        .annotate_numbers = true,
+        .overlay_signal   = true,
+        .signal_channels  = {15,16}, // CC + strange
+        .y_min            = 0.,
+        .y_max            = -1.,
+        .cuts             = { /* e.g. {1.2, rarexsec::plot::CutDir::GreaterThan} */ },
+        .beamline         = beamline,
+        .periods          = periods
+    });
 
-  rarexsec::plot::Hist1D h_len{
-    .name   = "trk_len",
-    .title  = "Leading track length;L_{trk} [cm];Events",
-    .expr   = "ROOT::VecOps::Max(track_length)", // any RDataFrame expression or column
-    .weight = "w_nominal",
-    .nbins  = 50, .xmin = 0., .xmax = 200.,
-    .sel    = rarexsec::selection::Preset::InclusiveMuCC
-  };
+    rarexsec::plot::Hist1D h_len{
+        .name   = "trk_len",
+        .title  = "Leading track length;L_{trk} [cm];Events",
+        .expr   = "ROOT::VecOps::Max(track_length)", // any RDataFrame expression or column
+        .weight = "w_nominal",
+        .nbins  = 50, .xmin = 0., .xmax = 200.,
+        .sel    = rarexsec::selection::Preset::InclusiveMuCC
+    };
 
-  plotter.draw_stack_by_channel(h_len, mc, data);
+    plotter.draw_stack_by_channel(h_len, mc, data);
 }


### PR DESCRIPTION
## Summary
- reindent the make_plots macro to use four-space indentation for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfb57ac9cc832e935d3e229eeba267