### PR TITLE
Remove obsolete channel order helper

### DIFF
--- a/include/rarexsec/plot/Channels.hh
+++ b/include/rarexsec/plot/Channels.hh
@@ -40,11 +40,6 @@ public:
         return properties(code).fill_style;
     }
 
-    static const std::vector<int>& order() {
-        static const std::vector<int> v = {1,2,14,10,11,12,13,18,17,15,16,99};
-        return v;
-    }
-
     static const std::vector<int>& signal_keys() {
         static const std::vector<int> v = {15,16};
         return v;


### PR DESCRIPTION
## Summary
- delete the unused Channels::order helper now that ordering is determined dynamically elsewhere

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfb59006d0832eb2c67f5d5d3c2f19