### PR TITLE
Simplify StackedHist construction

### DIFF
--- a/include/rarexsec/plot/StackedHist.hh
+++ b/include/rarexsec/plot/StackedHist.hh
@@ -17,13 +17,11 @@ namespace plot {
 
 class StackedHist {
 public:
-    StackedHist(std::string plot_name,
-                         std::string out_dir,
-                         Hist1D spec,
-                         Options opt,
-                         std::vector<const Entry*> mc,
-                         std::vector<const Entry*> data,
-                         std::vector<int> channel_order);
+    StackedHist(Hist1D spec,
+                Options opt,
+                std::vector<const Entry*> mc,
+                std::vector<const Entry*> data,
+                std::vector<int> channel_order);
     ~StackedHist() = default;
 
     void draw_and_save(const std::string& image_format);

--- a/src/Plotter.cc
+++ b/src/Plotter.cc
@@ -8,7 +8,7 @@ void Plotter::draw_stack_by_channel(const Hist1D& spec,
                                     const std::vector<const Entry*>& mc,
                                     const std::vector<const Entry*>& data) const {
     auto order = rarexsec::Channels::order();
-    StackedHist plot(spec.name, opt_.out_dir, spec, opt_, mc, data, order);
+    StackedHist plot(spec, opt_, mc, data, order);
     plot.draw_and_save(opt_.image_format);
 }
 

--- a/src/plot/StackedHist.cc
+++ b/src/plot/StackedHist.cc
@@ -10,16 +10,14 @@
 using namespace rarexsec;
 using namespace rarexsec::plot;
 
-StackedHist::StackedHist(std::string plot_name,
-                                           std::string out_dir,
-                                           Hist1D spec,
+StackedHist::StackedHist(Hist1D spec,
                                            Options opt,
                                            std::vector<const Entry*> mc,
                                            std::vector<const Entry*> data,
                                            std::vector<int> channel_order)
 : spec_(std::move(spec)), opt_(std::move(opt))
 , mc_(std::move(mc)), data_(std::move(data)), chan_order_(std::move(channel_order))
-, plot_name_(Plotter::sanitise(std::move(plot_name))), output_directory_(std::move(out_dir)) {}
+, plot_name_(Plotter::sanitise(spec_.name)), output_directory_(opt_.out_dir) {}
 
 void StackedHist::setup_pads_ratio(TCanvas& c, TPad*& p_main, TPad*& p_ratio) const {
     c.cd();


### PR DESCRIPTION
## Summary
- remove redundant plot name and output directory parameters from `StackedHist`
- rely on the histogram spec and plot options to derive the plot name and destination

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfba67a98c832ea4d38696ec1ebae0