### PR TITLE
Add batch flag to ROOT wrapper

### DIFF
--- a/rarexsec-root.sh
+++ b/rarexsec-root.sh
@@ -62,4 +62,4 @@ export ROOT_INCLUDE_PATH="${INCDIR}:${ROOT_INCLUDE_PATH}"
 
 LIBEXT="so"
 
-root -l -q -e "gROOT->LoadMacro(\"${MACRO}\"); setup_rarexsec(\"${LIBDIR}/librarexsec.${LIBEXT}\",\"${INCDIR}\");" "$@"
+root -l -b -q -e "gROOT->LoadMacro(\"${MACRO}\"); setup_rarexsec(\"${LIBDIR}/librarexsec.${LIBEXT}\",\"${INCDIR}\");" "$@"


### PR DESCRIPTION
## Summary
- ensure the ROOT wrapper runs in batch mode to avoid X11 dependency errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc912578c832ea9dac15477f163c9