### PR TITLE
Update stacked histogram legend formatting

### DIFF
--- a/include/rarexsec/plot/StackedHist.hh
+++ b/include/rarexsec/plot/StackedHist.hh
@@ -5,6 +5,7 @@
 #include "TH1.h"
 #include "THStack.h"
 #include "TLegend.h"
+#include "TLegendEntry.h"
 #include "TCanvas.h"
 #include "TPad.h"
 
@@ -48,6 +49,7 @@ private:
     std::unique_ptr<TH1D> data_hist_;
     std::unique_ptr<TH1D> sig_hist_;
     std::vector<int> chan_order_;
+    double signal_scale_ = 1.0;
 };
 
 }


### PR DESCRIPTION
## Summary
- update the stacked histogram legend to use styled entries and column layout consistent with the new plot design
- track the derived signal scale factor so the legend can report the applied scaling when overlays are enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfca35bd0c832ea97b6e371820f448