### PR TITLE
Rename setGlobalStyle to snake_case

### DIFF
--- a/include/rarexsec/Plotter.hh
+++ b/include/rarexsec/Plotter.hh
@@ -57,7 +57,7 @@ public:
                                const std::vector<const Entry*>& mc,
                                const std::vector<const Entry*>& data = {}) const;
 
-    virtual void setGlobalStyle() const;
+    virtual void set_global_style() const;
 
     static std::string fmt_commas(double v, int prec = -1) {
         std::ostringstream s;

--- a/src/Plotter.cc
+++ b/src/Plotter.cc
@@ -7,12 +7,12 @@
 void rarexsec::plot::Plotter::draw_stack_by_channel(const H1Spec& spec,
                                     const std::vector<const Entry*>& mc,
                                     const std::vector<const Entry*>& data) const {
-    setGlobalStyle();
+    set_global_style();
     StackedHist plot(spec, opt_, mc, data);
     plot.draw_and_save(opt_.image_format);
 }
 
-void rarexsec::plot::Plotter::setGlobalStyle() const {
+void rarexsec::plot::Plotter::set_global_style() const {
     const int font_style = 42;
     TStyle* style = new TStyle("PlotterStyle", "Plotter Style");
     style->SetTitleFont(font_style, "X");


### PR DESCRIPTION
## Summary
- rename the Plotter global styling helper to snake_case to follow naming conventions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfcbc8cc94832ea0668c61559f2496