### PR TITLE
Remove histogram title strings entirely

### DIFF
--- a/include/rarexsec/Plotter.hh
+++ b/include/rarexsec/Plotter.hh
@@ -29,7 +29,7 @@ struct H1Spec {
     selection::Preset sel = selection::Preset::Empty;
 
     ROOT::RDF::TH1DModel model(const std::string& suffix) const {
-        return ROOT::RDF::TH1DModel((id + suffix).c_str(), title.c_str(), nbins, xmin, xmax);
+        return ROOT::RDF::TH1DModel((id + suffix).c_str(), "", nbins, xmin, xmax);
     }
 };
 

--- a/macros/make_plots.C
+++ b/macros/make_plots.C
@@ -33,7 +33,7 @@ void make_plots() {
 
     rarexsec::plot::Hist1D h_len{
         .name   = "trk_len",
-        .title  = "Leading track length;L_{trk} [cm];Events",
+        .title  = "",
         .expr   = "ROOT::VecOps::Max(track_length)", // any RDataFrame expression or column
         .weight = "w_nominal",
         .nbins  = 50, .xmin = 0., .xmax = 200.,

--- a/macros/plot_true_vertex.C
+++ b/macros/plot_true_vertex.C
@@ -47,7 +47,7 @@ void plot_true_vertex() {
     const std::array<rarexsec::plot::H1Spec, 3> plots = {
         rarexsec::plot::H1Spec{
             .id = "true_vertex_x",
-            .title = "True neutrino vertex X;x^{true}_{#nu} [cm];Events",
+            .title = "",
             .expr = "neutrino_vertex_x",
             .weight = "w_nominal",
             .nbins = 50,
@@ -57,7 +57,7 @@ void plot_true_vertex() {
         },
         rarexsec::plot::H1Spec{
             .id = "true_vertex_y",
-            .title = "True neutrino vertex Y;y^{true}_{#nu} [cm];Events",
+            .title = "",
             .expr = "neutrino_vertex_y",
             .weight = "w_nominal",
             .nbins = 50,
@@ -67,7 +67,7 @@ void plot_true_vertex() {
         },
         rarexsec::plot::H1Spec{
             .id = "true_vertex_z",
-            .title = "True neutrino vertex Z;z^{true}_{#nu} [cm];Events",
+            .title = "",
             .expr = "neutrino_vertex_z",
             .weight = "w_nominal",
             .nbins = 80,

--- a/src/plot/StackedHist.cc
+++ b/src/plot/StackedHist.cc
@@ -42,7 +42,7 @@ void rarexsec::plot::StackedHist::setup_pads(TCanvas& c, TPad*& p_main, TPad*& p
 }
 
 void rarexsec::plot::StackedHist::build_histograms() {
-    stack_ = std::make_unique<THStack>((spec_.id + "_stack").c_str(), spec_.title.c_str());
+    stack_ = std::make_unique<THStack>((spec_.id + "_stack").c_str(), "");
     signal_scale_ = 1.0;
     std::map<int, std::vector<ROOT::RDF::RResultPtr<TH1D>>> booked;
     const auto& channels = rarexsec::plot::Channels::mc_keys();


### PR DESCRIPTION
## Summary
- build histogram models and stacks with empty titles so plots never render titles
- remove hard-coded title strings from plotting macros to avoid reintroducing them

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfcc4c44bc832e85fbe47c92154616