### PR TITLE
Restore histogram axis labels without plot titles

### DIFF
--- a/include/rarexsec/Plotter.hh
+++ b/include/rarexsec/Plotter.hh
@@ -28,8 +28,16 @@ struct H1Spec {
     double xmax = 1.;
     selection::Preset sel = selection::Preset::Empty;
 
+    std::string axis_title() const {
+        if (title.empty()) return "";
+        const auto pos = title.find(';');
+        if (pos == std::string::npos) return ";" + title;
+        return title.substr(pos);
+    }
+
     ROOT::RDF::TH1DModel model(const std::string& suffix) const {
-        return ROOT::RDF::TH1DModel((id + suffix).c_str(), title.c_str(), nbins, xmin, xmax);
+        const auto axes = axis_title();
+        return ROOT::RDF::TH1DModel((id + suffix).c_str(), axes.c_str(), nbins, xmin, xmax);
     }
 };
 

--- a/macros/make_plots.C
+++ b/macros/make_plots.C
@@ -33,7 +33,7 @@ void make_plots() {
 
     rarexsec::plot::Hist1D h_len{
         .name   = "trk_len",
-        .title  = "Leading track length;L_{trk} [cm];Events",
+        .title  = ";L_{trk} [cm];Events",
         .expr   = "ROOT::VecOps::Max(track_length)", // any RDataFrame expression or column
         .weight = "w_nominal",
         .nbins  = 50, .xmin = 0., .xmax = 200.,

--- a/macros/plot_true_vertex.C
+++ b/macros/plot_true_vertex.C
@@ -47,7 +47,7 @@ void plot_true_vertex() {
     const std::array<rarexsec::plot::H1Spec, 3> plots = {
         rarexsec::plot::H1Spec{
             .id = "true_vertex_x",
-            .title = "True neutrino vertex X;x^{true}_{#nu} [cm];Events",
+            .title = ";x^{true}_{#nu} [cm];Events",
             .expr = "neutrino_vertex_x",
             .weight = "w_nominal",
             .nbins = 50,
@@ -57,7 +57,7 @@ void plot_true_vertex() {
         },
         rarexsec::plot::H1Spec{
             .id = "true_vertex_y",
-            .title = "True neutrino vertex Y;y^{true}_{#nu} [cm];Events",
+            .title = ";y^{true}_{#nu} [cm];Events",
             .expr = "neutrino_vertex_y",
             .weight = "w_nominal",
             .nbins = 50,
@@ -67,7 +67,7 @@ void plot_true_vertex() {
         },
         rarexsec::plot::H1Spec{
             .id = "true_vertex_z",
-            .title = "True neutrino vertex Z;z^{true}_{#nu} [cm];Events",
+            .title = ";z^{true}_{#nu} [cm];Events",
             .expr = "neutrino_vertex_z",
             .weight = "w_nominal",
             .nbins = 80,

--- a/src/plot/StackedHist.cc
+++ b/src/plot/StackedHist.cc
@@ -42,7 +42,8 @@ void rarexsec::plot::StackedHist::setup_pads(TCanvas& c, TPad*& p_main, TPad*& p
 }
 
 void rarexsec::plot::StackedHist::build_histograms() {
-    stack_ = std::make_unique<THStack>((spec_.id + "_stack").c_str(), spec_.title.c_str());
+    const auto axes = spec_.axis_title();
+    stack_ = std::make_unique<THStack>((spec_.id + "_stack").c_str(), axes.c_str());
     signal_scale_ = 1.0;
     std::map<int, std::vector<ROOT::RDF::RResultPtr<TH1D>>> booked;
     const auto& channels = rarexsec::plot::Channels::mc_keys();


### PR DESCRIPTION
## Summary
- derive axis-only histogram title strings so booked histograms and stacks keep labels without a main title
- update plotting macros to provide axis label text while leaving the plot title blank

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfcc4c44bc832e85fbe47c92154616