### PR TITLE
Enhance stacked plot options and layout

### DIFF
--- a/include/rarexsec/Plotter.hh
+++ b/include/rarexsec/Plotter.hh
@@ -1,12 +1,15 @@
 #pragma once
 #include <cctype>
 #include <iomanip>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
 #include "ROOT/RDataFrame.hxx"
 #include "rarexsec/proc/Selection.hh"
 #include "rarexsec/Hub.hh"
+
+class TMatrixDSym;
 
 namespace rarexsec {
 namespace plot {
@@ -46,16 +49,25 @@ struct Options {
     std::string image_format = "png";
     bool show_ratio = true;
     bool use_log_y = false;
+    bool overlay_signal = true;
     bool annotate_numbers = true;
-    bool overlay_signal = false;
-    std::vector<int> signal_channels = {15,16};
-    double y_min = 0.;
-    double y_max = -1.;
-    bool show_cuts = true;
+    double y_min = 0.0;
+    double y_max = -1.0;
+    double leg_x1 = 0.12, leg_y1 = 0.60, leg_x2 = 0.95, leg_y2 = 0.88;
+    std::vector<int> signal_channels;
+    bool show_cuts = false;
     std::vector<CutLine> cuts;
+
+    bool legend_on_top = true;
+    double legend_split = 0.85;
+    std::vector<double> rebin_edges;
+    std::shared_ptr<TMatrixDSym> total_cov;
+    std::vector<double> syst_bin;
+    bool show_ratio_band = true;
+    std::string x_title;
+    std::string y_title = "Events";
     std::string beamline;
     std::vector<std::string> periods;
-    double leg_x1 = 0.60, leg_y1 = 0.55, leg_x2 = 0.88, leg_y2 = 0.88;
 };
 
 class Plotter {

--- a/include/rarexsec/plot/StackedHist.hh
+++ b/include/rarexsec/plot/StackedHist.hh
@@ -30,7 +30,7 @@ protected:
 private:
     bool want_ratio() const { return opt_.show_ratio && data_hist_ && mc_total_; }
     void build_histograms();
-    void setup_pads(TCanvas& c, TPad*& p_main, TPad*& p_ratio) const;
+    void setup_pads(TCanvas& c, TPad*& p_main, TPad*& p_ratio, TPad*& p_legend) const;
     void draw_stack_and_unc(TPad* p_main, double& max_y);
     void draw_ratio(TPad* p_ratio);
     void draw_legend(TPad* p);
@@ -50,6 +50,7 @@ private:
     std::unique_ptr<TH1D> sig_hist_;
     std::vector<int> chan_order_;
     double signal_scale_ = 1.0;
+    mutable std::vector<std::unique_ptr<TH1D>> legend_proxies_;
 };
 
 }

--- a/macros/plot_true_vertex.C
+++ b/macros/plot_true_vertex.C
@@ -39,6 +39,10 @@ void plot_true_vertex() {
     plot_options.out_dir = out_dir;
     plot_options.image_format = "png";
     plot_options.show_ratio = false;
+    plot_options.overlay_signal = false;
+    plot_options.legend_on_top = true;
+    plot_options.legend_split = 0.85;
+    plot_options.y_title = "Events";
     plot_options.beamline = beamline;
     plot_options.periods = periods;
 


### PR DESCRIPTION
## Summary
- extend plotter options with legend layout, rebinning, axis title, and uncertainty controls, and refresh the true-vertex macro defaults
- update stacked histogram drawing to support a dedicated legend pad, systematic-plus-statistical error bands, rebinning, and ratio uncertainty bands while keeping legend proxies alive

## Testing
- `ninja -C build` *(fails: build.ninja not generated in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd0c8956c832e803e103c48337a65