### PR TITLE
Fix ROOT forward declaration conflict

### DIFF
--- a/include/rarexsec/Plotter.hh
+++ b/include/rarexsec/Plotter.hh
@@ -8,8 +8,7 @@
 #include "ROOT/RDataFrame.hxx"
 #include "rarexsec/proc/Selection.hh"
 #include "rarexsec/Hub.hh"
-
-class TMatrixDSym;
+#include "TMatrixDSymfwd.h"
 
 namespace rarexsec {
 namespace plot {


### PR DESCRIPTION
## Summary
- include ROOT's TMatrixDSym forward declaration header in Plotter.hh
- remove the manual forward declaration that conflicted with ROOT's typedef

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd342da7c832eb75b6d1ce37011c3