### PR TITLE
Remove error bar overlay from MC uncertainty band

### DIFF
--- a/src/plot/StackedHist.cc
+++ b/src/plot/StackedHist.cc
@@ -271,7 +271,6 @@ void rarexsec::plot::StackedHist::draw_stack_and_unc(TPad* p_main, double& max_y
         h->SetLineColor(kBlack);
         h->SetLineWidth(1);
         h->Draw("E2 SAME");
-        h->Draw("E1 SAME");
     }
     if (sig_hist_)  sig_hist_->Draw("HIST SAME");
     if (data_hist_) data_hist_->Draw("E1 SAME");


### PR DESCRIPTION
## Summary
- stop drawing the MC total uncertainty band with an additional error bar overlay so it appears as an envelope only

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfd9db09ec832e9c80dba09a2154e0