### PR TITLE
Ensure stacked histogram outlines are black

### DIFF
--- a/src/plot/StackedHist.cc
+++ b/src/plot/StackedHist.cc
@@ -5,6 +5,7 @@
 #include "TLine.h"
 #include "TLatex.h"
 #include "TMatrixDSym.h"
+#include "TList.h"
 #include <algorithm>
 #include <cmath>
 #include <filesystem>
@@ -239,6 +240,15 @@ void rarexsec::plot::StackedHist::build_histograms() {
 void rarexsec::plot::StackedHist::draw_stack_and_unc(TPad* p_main, double& max_y) {
     if (!p_main) return;
     p_main->cd();
+
+    if (auto* hists = stack_->GetHists()) {
+        for (TObject* obj = hists->First(); obj != nullptr; obj = hists->After(obj)) {
+            if (auto* hist = dynamic_cast<TH1*>(obj)) {
+                hist->SetLineColor(kBlack);
+            }
+        }
+    }
+
     stack_->Draw("HIST");
     TH1* frame = stack_->GetHistogram();
     if (frame) {


### PR DESCRIPTION
## Summary
- ensure every histogram in the stack uses a black outline before drawing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfd9add3ac832e896a2403498fead1