### PR TITLE
Handle escaped quotes in rarexsec-root arguments

### DIFF
--- a/rarexsec-root.sh
+++ b/rarexsec-root.sh
@@ -62,4 +62,9 @@ export ROOT_INCLUDE_PATH="${INCDIR}:${ROOT_INCLUDE_PATH}"
 
 LIBEXT="so"
 
-root -l -b -q -e "gROOT->LoadMacro(\"${MACRO}\"); setup_rarexsec(\"${LIBDIR}/librarexsec.${LIBEXT}\",\"${INCDIR}\");" "$@"
+args=()
+for arg in "$@"; do
+  args+=("${arg//\\\"/\"}")
+done
+
+root -l -b -q -e "gROOT->LoadMacro(\"${MACRO}\"); setup_rarexsec(\"${LIBDIR}/librarexsec.${LIBEXT}\",\"${INCDIR}\");" "${args[@]}"


### PR DESCRIPTION
## Summary
- normalize escaped quotes in arguments passed to rarexsec-root so macros invoked with escaped strings work as expected

## Testing
- not run (environment lacks ROOT)


------
https://chatgpt.com/codex/tasks/task_e_68dff28820b8832eb1bbe42670fbc17f