### PR TITLE
Add forward declarations to ROOT wrapper macro

### DIFF
--- a/rarexsec-root.sh
+++ b/rarexsec-root.sh
@@ -69,6 +69,8 @@ ESC_INC="$(escape_cpp_string "${INCDIR}")"
 TMP_MACRO="$(mktemp "${TMPDIR:-/tmp}/rarexsec-root-XXXX.C")"
 trap 'rm -f "${TMP_MACRO}"; unset RAREXSEC_CALL' EXIT
 cat >"${TMP_MACRO}" <<EOF
+void setup_rarexsec(const char*, const char*);
+void rx_call(const char*);
 void rarexsec_root_entry() {
   gROOT->LoadMacro("${ESC_MACRO}");
   setup_rarexsec("${ESC_LIB}","${ESC_INC}");


### PR DESCRIPTION
## Summary
- add forward declarations for setup_rarexsec and rx_call before invoking the ROOT entrypoint macro

## Testing
- not run (ROOT is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3b6ac045c832ea3004e7ee0d8cd20