### PR TITLE
Fix ROOT temporary macro invocation for rarexsec-root

### DIFF
--- a/rarexsec-root.sh
+++ b/rarexsec-root.sh
@@ -81,6 +81,10 @@ void rarexsec_root_entry() {
   }
   rx_call(call);
 }
-rarexsec_root_entry();
+namespace {
+  struct RarexsecRootInvoker {
+    RarexsecRootInvoker() { rarexsec_root_entry(); }
+  } rarexsec_root_invoker;
+}
 EOF
 root -l -b -q "${TMP_MACRO}"


### PR DESCRIPTION
## Summary
- wrap the rarexsec_root_entry call in a static helper so the generated macro remains valid C++

## Testing
- ./rarexsec-root.sh -c macros/PlotPOT_Simple.C *(fails: root binary is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b73f77b8832e8cc02dad0f700b26