### PR TITLE
Ensure PlotPOT macro loads sqlite3 library

### DIFF
--- a/macros/PlotPOT_Simple.C
+++ b/macros/PlotPOT_Simple.C
@@ -35,6 +35,10 @@ static time_t sunday_after_or_on(time_t t) {
 
 void PlotPOT_Simple(const char* outstem = "pot_timeline")
 {
+  if (gSystem->Load("libsqlite3.so") < 0) {
+    std::cerr << "Failed to load libsqlite3.so\n";
+    return;
+  }
   const std::string run_db  = DBROOT() + "/run.db";
   const std::string bnb_db  = gSystem->AccessPathName((DBROOT()+"/bnb_v2.db").c_str()) ?
                               DBROOT()+"/bnb_v1.db" : DBROOT()+"/bnb_v2.db";


### PR DESCRIPTION
## Summary
- load libsqlite3 before executing the PlotPOT_Simple macro so its SQLite symbols are available
- provide a clear error message and early return if the library cannot be loaded

## Testing
- `./rarexsec-root.sh -c macros/PlotPOT_Simple.C` *(fails: root command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b826282c832ebb18d0478fe2fd40