### PR TITLE
Make Plotter global style method accessible

### DIFF
--- a/include/rarexsec/Plotter.hh
+++ b/include/rarexsec/Plotter.hh
@@ -83,7 +83,6 @@ public:
         return with_commas + fraction;
     }
 
-private:
     void set_global_style() const {
         const int font_style = 42;
         TStyle* style = new TStyle("PlotterStyle", "Plotter Style");
@@ -124,6 +123,7 @@ private:
         gROOT->ForceStyle();
     }
 
+private:
     Options opt_;
 };
 


### PR DESCRIPTION
## Summary
- expose `rarexsec::plot::Plotter::set_global_style` so macros can configure ROOT styling

## Testing
- ./rarexsec-root.sh -c macros/PlotPOT_Simple.C *(fails: `root` not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c1405dd8832ea383ec90b6b350ef