### PR TITLE
Remove TGaxis::SetAxisColor call for compatibility

### DIFF
--- a/macros/PlotPOT_Simple.C
+++ b/macros/PlotPOT_Simple.C
@@ -193,7 +193,6 @@ void PlotPOT_Simple(const char* outstem = "pot_timeline")
 
   TGaxis right(hs.GetXaxis()->GetXmax(), 0, hs.GetXaxis()->GetXmax(), yMax,
                0, maxCum, 510, "+L");
-  right.SetAxisColor(kBlue+1);
   right.SetLineColor(kBlue+1);
   right.SetLabelColor(kBlue+1);
   right.SetTitleColor(kBlue+1);


### PR DESCRIPTION
## Summary
- remove the TGaxis::SetAxisColor invocation so the macro builds with ROOT versions that lack it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c5f524c4832ea1df5d525fe7ec5f