### PR TITLE
Add unstacked histogram overlay plotting helper

### DIFF
--- a/include/rarexsec/Plotter.hh
+++ b/include/rarexsec/Plotter.hh
@@ -12,6 +12,7 @@
 
 #include "rarexsec/Hub.hh"
 #include "rarexsec/plot/StackedHist.hh"
+#include "rarexsec/plot/UnstackedHist.hh"
 #include "rarexsec/plot/Types.hh"
 
 namespace rarexsec::plot {
@@ -37,6 +38,24 @@ public:
                                const std::vector<const Entry*>& data) const {
         set_global_style();
         StackedHist plot(spec, opt_, mc, data);
+        plot.draw_and_save(opt_.image_format);
+    }
+
+    void draw_unstacked_by_channel(const H1Spec& spec,
+                                   const std::vector<const Entry*>& mc,
+                                   bool normalize_to_pdf = true,
+                                   int line_width = 3) const {
+        static const std::vector<const Entry*> empty_data{};
+        draw_unstacked_by_channel(spec, mc, empty_data, normalize_to_pdf, line_width);
+    }
+
+    void draw_unstacked_by_channel(const H1Spec& spec,
+                                   const std::vector<const Entry*>& mc,
+                                   const std::vector<const Entry*>& data,
+                                   bool normalize_to_pdf,
+                                   int line_width) const {
+        set_global_style();
+        UnstackedHist plot(spec, opt_, mc, data, normalize_to_pdf, line_width);
         plot.draw_and_save(opt_.image_format);
     }
 

--- a/include/rarexsec/plot/UnstackedHist.hh
+++ b/include/rarexsec/plot/UnstackedHist.hh
@@ -1,0 +1,63 @@
+#ifndef RAREXSEC_PLOT_UNSTACKEDHIST_HH
+#define RAREXSEC_PLOT_UNSTACKEDHIST_HH
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class TCanvas;
+class TLegend;
+class TPad;
+class TH1D;
+
+namespace rarexsec {
+  struct Entry;
+  namespace plot {
+    struct H1Spec;
+    struct Options;
+
+    /// Draws unstacked (overlay) histograms by analysis channel.
+    /// Reuses H1Spec/Options and Channels styling from rarexsec.
+    class UnstackedHist {
+    public:
+      UnstackedHist(H1Spec spec,
+                    Options opt,
+                    std::vector<const Entry*> mc,
+                    std::vector<const Entry*> data = {},
+                    bool normalize_to_pdf = true,
+                    int  line_width = 3);
+
+      void draw(TCanvas& canvas);
+      void draw_and_save(const std::string& image_format = "");
+
+    private:
+      void build_histograms();
+      void setup_pads(TCanvas& c, TPad*& p_main, TPad*& p_legend) const;
+      void draw_curves(TPad* p_main, double& max_y);
+      void draw_legend(TPad* p_legend);
+      void draw_watermark(TPad* p_main) const;
+
+      // inputs
+      H1Spec spec_;
+      Options opt_;
+      std::vector<const Entry*> mc_;
+      std::vector<const Entry*> data_;
+      bool normalize_to_pdf_;
+      int  line_width_;
+
+      // runtime
+      std::string plot_name_;
+      std::string output_directory_;
+
+      std::vector<int> chan_order_;
+      std::vector<std::unique_ptr<TH1D>> mc_ch_hists_; // one per channel
+      std::unique_ptr<TH1D> data_hist_;                // optional
+
+      std::unique_ptr<TLegend> legend_;
+      std::vector<std::unique_ptr<TH1D>> legend_proxies_;
+    };
+
+  } // namespace plot
+} // namespace rarexsec
+
+#endif

--- a/src/plot/UnstackedHist.cc
+++ b/src/plot/UnstackedHist.cc
@@ -1,0 +1,266 @@
+#include "rarexsec/plot/UnstackedHist.hh"
+
+#include <ROOT/RDataFrame.hxx>
+#include <ROOT/RDFHelpers.hxx>
+#include <TCanvas.h>
+#include <TLegend.h>
+#include <TPad.h>
+#include <TH1D.h>
+#include <TLatex.h>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+#include "rarexsec/Plotter.hh"                // H1Spec, Options, Plotter::fmt_commas/sanitise
+#include "rarexsec/plot/Channels.hh"          // channel colors/labels/order
+#include "rarexsec/Selection.hh"              // selection::apply
+#include "rarexsec/Hub.hh"                    // Entry
+
+namespace {
+inline void normalise_pdf(TH1D& h) {
+  const double area = h.Integral("width");
+  if (area > 0.0) h.Scale(1.0 / area);
+}
+} // namespace
+
+namespace rarexsec::plot {
+
+UnstackedHist::UnstackedHist(H1Spec spec,
+                             Options opt,
+                             std::vector<const Entry*> mc,
+                             std::vector<const Entry*> data,
+                             bool normalize_to_pdf,
+                             int line_width)
+  : spec_(std::move(spec))
+  , opt_(std::move(opt))
+  , mc_(std::move(mc))
+  , data_(std::move(data))
+  , normalize_to_pdf_(normalize_to_pdf)
+  , line_width_(line_width)
+  , plot_name_(rarexsec::plot::Plotter::sanitise(spec_.id))
+  , output_directory_(opt_.out_dir) {}
+
+void UnstackedHist::setup_pads(TCanvas& c, TPad*& p_main, TPad*& p_legend) const {
+  c.cd();
+  p_main = nullptr; p_legend = nullptr;
+  const double split = std::clamp(opt_.legend_split, 0.60, 0.95);
+
+  if (opt_.legend_on_top) {
+    p_main   = new TPad("pad_main",   "pad_main",   0., 0.00, 1., split);
+    p_legend = new TPad("pad_legend", "pad_legend", 0., split, 1., 1.00);
+
+    p_main  ->SetTopMargin(0.01);  p_main  ->SetBottomMargin(0.12);
+    p_main  ->SetLeftMargin(0.12); p_main  ->SetRightMargin(0.05);
+    p_legend->SetTopMargin(0.05);  p_legend->SetBottomMargin(0.01);
+    p_legend->SetLeftMargin(0.02); p_legend->SetRightMargin(0.02);
+
+    if (opt_.use_log_y) p_main->SetLogy();
+
+    p_main->Draw(); p_legend->Draw();
+  } else {
+    p_main  = new TPad("pad_main","pad_main", 0.,0.,1.,1.);
+    p_main ->SetTopMargin(0.06);  p_main ->SetBottomMargin(0.12);
+    p_main ->SetLeftMargin(0.12); p_main ->SetRightMargin(0.05);
+    if (opt_.use_log_y) p_main->SetLogy();
+    p_main->Draw();
+  }
+}
+
+void UnstackedHist::build_histograms() {
+  mc_ch_hists_.clear();
+  data_hist_.reset();
+  chan_order_.clear();
+
+  // Book per-channel histograms across all MC entries
+  std::map<int, std::vector<ROOT::RDF::RResultPtr<TH1D>>> booked_mc;
+  const auto& channels = rarexsec::plot::Channels::mc_keys();
+
+  for (size_t ie = 0; ie < mc_.size(); ++ie) {
+    const Entry* e = mc_[ie];
+    if (!e) continue;
+
+    auto n0 = selection::apply(e->rnode(), spec_.sel, *e);
+    auto n  = (spec_.expr.empty() ? n0 : n0.Define("_rx_expr_", spec_.expr));
+    const std::string var = spec_.expr.empty() ? spec_.id : "_rx_expr_";
+
+    for (int ch : channels) {
+      auto nf = n.Filter([ch](int c){ return c == ch; }, {"analysis_channels"});
+      auto h  = nf.Histo1D(spec_.model("_mc_ch"+std::to_string(ch)+"_src"+std::to_string(ie)), var, spec_.weight);
+      booked_mc[ch].push_back(h);
+    }
+  }
+
+  // Sum per-channel across entries; order by pre-normalization yield
+  std::vector<std::pair<int,double>> yields;
+  std::map<int, std::unique_ptr<TH1D>> sum_by_channel;
+
+  for (int ch : channels) {
+    auto it = booked_mc.find(ch);
+    if (it == booked_mc.end() || it->second.empty()) continue;
+
+    std::unique_ptr<TH1D> sum;
+    for (auto& rr : it->second) {
+      const TH1D& h = rr.GetValue();
+      if (!sum) {
+        sum.reset(static_cast<TH1D*>(h.Clone((spec_.id+"_sum_ch"+std::to_string(ch)).c_str())));
+        sum->SetDirectory(nullptr);
+      } else {
+        sum->Add(&h);
+      }
+    }
+    if (sum) {
+      const double y = sum->Integral();
+      yields.emplace_back(ch, y);
+      sum_by_channel.emplace(ch, std::move(sum));
+    }
+  }
+
+  std::stable_sort(yields.begin(), yields.end(), [](const auto& a, const auto& b){
+    if (a.second == b.second) return a.first < b.first;
+    return a.second > b.second;
+  });
+
+  // Style: lines by channel color; optional PDF normalization
+  for (auto& [ch, /*y*/_] : yields) {
+    auto it = sum_by_channel.find(ch);
+    if (it == sum_by_channel.end()) continue;
+    auto& h = it->second;
+
+    if (normalize_to_pdf_) normalise_pdf(*h);
+
+    h->SetFillStyle(0);
+    h->SetLineColor(rarexsec::plot::Channels::color(ch));
+    h->SetLineWidth(line_width_);
+
+    mc_ch_hists_.push_back(std::move(h));
+    chan_order_.push_back(ch);
+  }
+
+  // Optional data overlay (pooled)
+  if (!data_.empty()) {
+    std::vector<ROOT::RDF::RResultPtr<TH1D>> parts;
+    for (size_t ie = 0; ie < data_.size(); ++ie) {
+      const Entry* e = data_[ie];
+      if (!e) continue;
+      auto n0 = selection::apply(e->rnode(), spec_.sel, *e);
+      auto n  = (spec_.expr.empty() ? n0 : n0.Define("_rx_expr_", spec_.expr));
+      const std::string var = spec_.expr.empty() ? spec_.id : "_rx_expr_";
+      parts.push_back(n.Histo1D(spec_.model("_data_src"+std::to_string(ie)), var));
+    }
+    for (auto& rr : parts) {
+      const TH1D& h = rr.GetValue();
+      if (!data_hist_) {
+        data_hist_.reset(static_cast<TH1D*>(h.Clone((spec_.id+"_data").c_str())));
+        data_hist_->SetDirectory(nullptr);
+      } else {
+        data_hist_->Add(&h);
+      }
+    }
+    if (data_hist_) {
+      if (normalize_to_pdf_) normalise_pdf(*data_hist_);
+      data_hist_->SetMarkerStyle(kFullCircle);
+      data_hist_->SetMarkerSize(0.9);
+      data_hist_->SetLineColor(kBlack);
+      data_hist_->SetFillStyle(0);
+    }
+  }
+}
+
+void UnstackedHist::draw_curves(TPad* p_main, double& max_y) {
+  if (!p_main) return;
+  p_main->cd();
+
+  // find max
+  max_y = 0.;
+  for (auto& h : mc_ch_hists_) max_y = std::max(max_y, h->GetMaximum());
+  if (data_hist_) max_y = std::max(max_y, data_hist_->GetMaximum());
+  if (opt_.y_max > 0) max_y = opt_.y_max;
+
+  if (mc_ch_hists_.empty()) return;
+  TH1D* frame = mc_ch_hists_.front().get();
+
+  if (spec_.xmin < spec_.xmax) frame->GetXaxis()->SetLimits(spec_.xmin, spec_.xmax);
+  frame->SetTitle((spec_.title.empty() ? (";"+opt_.x_title+";"+opt_.y_title) : spec_.title).c_str());
+  if (!opt_.x_title.empty()) frame->GetXaxis()->SetTitle(opt_.x_title.c_str());
+  if (!opt_.y_title.empty()) frame->GetYaxis()->SetTitle(opt_.y_title.c_str());
+  if (normalize_to_pdf_)      frame->GetYaxis()->SetTitle("Probability density");
+
+  frame->SetMaximum(max_y * (opt_.use_log_y ? 10. : 1.3));
+  frame->SetMinimum(opt_.use_log_y ? 0.1 : opt_.y_min);
+
+  frame->Draw("HIST");
+  for (size_t i = 1; i < mc_ch_hists_.size(); ++i) {
+    mc_ch_hists_[i]->Draw("HIST SAME");
+  }
+  if (data_hist_) data_hist_->Draw("E1 SAME");
+}
+
+void UnstackedHist::draw_legend(TPad* p) {
+  if (!p) return;
+  p->cd();
+  legend_ = std::make_unique<TLegend>(0.12, 0.0, 0.95, 0.75);
+  auto* leg = legend_.get();
+  if (!opt_.legend_on_top) {
+    leg->SetX1NDC(opt_.leg_x1); leg->SetY1NDC(opt_.leg_y1);
+    leg->SetX2NDC(opt_.leg_x2); leg->SetY2NDC(opt_.leg_y2);
+  }
+  leg->SetBorderSize(0);
+  leg->SetFillStyle(0);
+  leg->SetTextFont(42);
+
+  legend_proxies_.clear();
+  for (size_t i = 0; i < mc_ch_hists_.size(); ++i) {
+    int ch = chan_order_.at(i);
+    auto proxy = std::unique_ptr<TH1D>(static_cast<TH1D*>(
+      mc_ch_hists_[i]->Clone((spec_.id+"_leg_ch"+std::to_string(ch)).c_str())));
+    proxy->SetDirectory(nullptr);
+    proxy->Reset("ICES");
+
+    proxy->SetFillStyle(0);
+    proxy->SetLineColor(mc_ch_hists_[i]->GetLineColor());
+    proxy->SetLineWidth(line_width_);
+
+    leg->AddEntry(proxy.get(), rarexsec::plot::Channels::label(ch).c_str(), "l");
+    legend_proxies_.push_back(std::move(proxy));
+  }
+  if (data_hist_) leg->AddEntry(data_hist_.get(), "Data", "lep");
+  leg->Draw();
+}
+
+void UnstackedHist::draw_watermark(TPad* p_main) const {
+  if (!p_main) return;
+  p_main->cd();
+  TLatex tl; tl.SetNDC(); tl.SetTextFont(42); tl.SetTextSize(0.04);
+  tl.DrawLatex(0.14, 0.92,
+     (std::string("#muBooNE Simulation – ")
+      + (opt_.analysis_region_label.empty() ? "Empty Selection" : opt_.analysis_region_label)).c_str());
+}
+
+void UnstackedHist::draw(TCanvas& canvas) {
+  build_histograms();
+  TPad *p_main = nullptr, *p_legend = nullptr;
+  setup_pads(canvas, p_main, p_legend);
+  double max_y = 1.;
+  draw_curves(p_main, max_y);
+  draw_watermark(p_main);
+  draw_legend(p_legend ? p_legend : p_main);
+  if (p_main) p_main->RedrawAxis();
+  canvas.Update();
+}
+
+void UnstackedHist::draw_and_save(const std::string& image_format) {
+  std::filesystem::create_directories(output_directory_);
+  TCanvas canvas(plot_name_.c_str(), plot_name_.c_str(), 900, 700);
+  draw(canvas);
+  const std::string fmt = image_format.empty() ? "png" : image_format;
+  canvas.SaveAs((output_directory_ + "/" + plot_name_ + "." + fmt).c_str());
+}
+
+} // namespace rarexsec::plot


### PR DESCRIPTION
## Summary
- add the `rarexsec::plot::UnstackedHist` helper for drawing per-channel overlay histograms
- expose `Plotter::draw_unstacked_by_channel` convenience wrappers that use the new helper

## Testing
- not run (ROOT tooling is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4afef612c832ebea772d71304de03