### PR TITLE
Fix UnstackedHist header dependencies

### DIFF
--- a/include/rarexsec/plot/UnstackedHist.hh
+++ b/include/rarexsec/plot/UnstackedHist.hh
@@ -5,6 +5,8 @@
 #include <string>
 #include <vector>
 
+#include "rarexsec/plot/Types.hh"
+
 class TCanvas;
 class TLegend;
 class TPad;
@@ -13,8 +15,6 @@ class TH1D;
 namespace rarexsec {
   struct Entry;
   namespace plot {
-    struct H1Spec;
-    struct Options;
 
     /// Draws unstacked (overlay) histograms by analysis channel.
     /// Reuses H1Spec/Options and Channels styling from rarexsec.


### PR DESCRIPTION
## Summary
- include the UnstackedHist type definitions to provide complete declarations for the stored H1Spec and Options members

## Testing
- make -C build -j8 *(fails: root-config not found in PATH in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cb47c568832eae1d93d8f5f792ea