### PR TITLE
Improve styling for semantic count plots

### DIFF
--- a/include/rarexsec/Plotter.hh
+++ b/include/rarexsec/Plotter.hh
@@ -9,6 +9,7 @@
 
 #include <TROOT.h>
 #include <TStyle.h>
+#include <TGaxis.h>
 
 #include "rarexsec/Hub.hh"
 #include "rarexsec/plot/StackedHist.hh"
@@ -120,8 +121,12 @@ public:
         style->SetTitleOffset(0.93, "X");
         style->SetTitleOffset(1.06, "Y");
         style->SetOptStat(0);
+        style->SetOptTitle(0);            // NEW: kill the ROOT title box
         style->SetPadTickX(1);
         style->SetPadTickY(1);
+
+        // Keep numbers readable (no ×10^n on axes, and limit digits)
+        TGaxis::SetMaxDigits(4);          // NEW: fewer digits before exponent kicks in
         style->SetPadLeftMargin(0.15);
         style->SetPadRightMargin(0.05);
         style->SetPadTopMargin(0.07);

--- a/macros/plot_semantic_count_shapes_perplane.C
+++ b/macros/plot_semantic_count_shapes_perplane.C
@@ -6,6 +6,8 @@
 #include <TLegend.h>
 #include <TH1D.h>
 #include <TLatex.h>
+#include <TStyle.h>
+#include <TGaxis.h>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -16,7 +18,7 @@
 #include "rarexsec/Hub.hh"
 #include "rarexsec/proc/Selection.hh"
 
-// Load user libs
+// Load user libs (unchanged)
 static void load_libs(const char* extra_libs) {
   gSystem->Load("librarexsec");
   if (!extra_libs) return;
@@ -34,6 +36,7 @@ static double sem_count(const std::vector<int>& counts, int lab) {
   return static_cast<double>(counts[lab]);
 }
 static void normalize_pdf(TH1D& h) { double A = h.Integral("width"); if (A>0.0) h.Scale(1.0/A); }
+
 static int discover_num_labels(const std::vector<const rarexsec::Entry*>& samples, const std::string& col) {
   using namespace rarexsec;
   int nlabels = 0;
@@ -46,9 +49,44 @@ static int discover_num_labels(const std::vector<const rarexsec::Entry*>& sample
   }
   return nlabels;
 }
-// simple palette
-static int color_for_label(int i){ static const int P[]={kBlack,kRed+1,kAzure+2,kGreen+2,kOrange+7,kMagenta+1,kCyan+2,kViolet+1,kTeal+3,kPink+7,kGray+2}; return P[i% (sizeof(P)/sizeof(int))]; }
-static std::string label_name(int i){ std::ostringstream ss; ss<<"label "<<i; return ss.str(); }
+
+// --------- semantic label naming ---------
+// Provide a sensible default mapping; if nlabels is different, we’ll fall back to "label i" for extras.
+// You can edit the names below to match your training/semantic scheme.
+static const std::vector<std::string> kDefaultSemanticNames = {
+  "Other/Background",     // 0
+  "Track-like (MIP)",     // 1
+  "Shower-like (EM)",     // 2
+  "Michel e^{-}",         // 3
+  "δ-ray e^{-}",          // 4
+  "Low-E deposit",        // 5
+  "HIP (Bragg)",          // 6
+  "Neutron-like",         // 7
+  "Proton-like",          // 8
+  "Pion-like",            // 9
+  "Kaon-like",            // 10
+  "γ/π^{0}",              // 11
+  "Cosmic μ",             // 12
+  "Cosmic shower",        // 13
+  "Noise/Dead"            // 14
+};
+
+static std::string label_name_from_map(int i, int nlabels) {
+  if (i >= 0 && i < (int)kDefaultSemanticNames.size() && (int)kDefaultSemanticNames.size() == nlabels) {
+    return kDefaultSemanticNames[i];
+  }
+  // Fallback if the default list doesn't match exactly
+  std::ostringstream ss; ss << "label " << i; return ss.str();
+}
+
+// simple (colorblind-friendly-ish) palette
+static int color_for_label(int i){
+  static const int P[] = {
+    kBlack, kRed+1, kAzure+2, kGreen+2, kOrange+7, kMagenta+1,
+    kCyan+2, kViolet+1, kTeal+3, kPink+7, kGray+2
+  };
+  return P[i % (int)(sizeof(P)/sizeof(int))];
+}
 
 void plot_semantic_count_shapes_perplane(const char* extra_libs = "",
                                          bool use_event_counts   = true,
@@ -62,6 +100,12 @@ void plot_semantic_count_shapes_perplane(const char* extra_libs = "",
   ROOT::EnableImplicitMT();
   load_libs(extra_libs);
 
+  // Global style (no stats box, ticks on both sides, no exponent by default)
+  gStyle->SetOptStat(0);
+  gStyle->SetPadTickX(1);
+  gStyle->SetPadTickY(1);
+  TGaxis::SetMaxDigits(4);
+
   rarexsec::Hub hub(config_path);
   const std::vector<std::string> periods = {period};
   const auto mc = hub.simulation_entries(beamline, periods);
@@ -72,40 +116,49 @@ void plot_semantic_count_shapes_perplane(const char* extra_libs = "",
 
   const char* Ucnt = use_event_counts ? "event_semantic_counts_u" : "slice_semantic_counts_u";
   const char* Vcnt = use_event_counts ? "event_semantic_counts_v" : "slice_semantic_counts_v";
-  const char* Wcnt = use_event_counts ? "event_semantic_counts_w" : "slice_semantic_counts_w";
+  const char* Ycnt = use_event_counts ? "event_semantic_counts_w" : "slice_semantic_counts_w"; // 'w' branch, but plane label is Y
 
-  struct Plane { const char* tag; const char* col; };
-  const Plane planes[3] = { {"u", Ucnt}, {"v", Vcnt}, {"w", Wcnt} };
+  struct Plane { const char* tag; const char* col; const char* pretty; };
+  const Plane planes[3] = { {"u", Ucnt, "U"}, {"v", Vcnt, "V"}, {"y", Ycnt, "Y"} };
 
   const int nlabels = discover_num_labels(mc, Ucnt);
   if (nlabels <= 0) { std::cerr << "No labels found.\n"; return; }
 
   for (const auto& p : planes) {
     std::vector<std::unique_ptr<TH1D>> H(nlabels);
+
     // pool all MC entries, no channel split
     for (size_t ie = 0; ie < mc.size(); ++ie) {
       const rarexsec::Entry* e = mc[ie];
       if (!e) continue;
       auto n0 = rarexsec::selection::apply(e->rnode(), rarexsec::selection::Preset::Empty, *e);
+
       for (int lab = 0; lab < nlabels; ++lab) {
         const std::string col = std::string("_rx_sc_") + p.tag + "_" + std::to_string(lab);
-    auto n1 = n0.Define(col, [lab](const std::vector<int>& v){ return sem_count(v, lab); }, {p.col});
-    auto rr = n1.Histo1D(ROOT::RDF::TH1DModel(("h_"+std::string(p.tag)+"_lab"+std::to_string(lab)+"_src"+std::to_string(ie)).c_str(),
-                                             (";"+std::string(1,(char)toupper(*p.tag))+"-plane semantic COUNT;Events").c_str(),
-                                             nbins, xmin, xmax),
-                          col, "w_nominal");
+        auto n1 = n0.Define(col, [lab](const std::vector<int>& v){ return sem_count(v, lab); }, {p.col});
+
+        auto rr = n1.Histo1D(
+            ROOT::RDF::TH1DModel(("h_"+std::string(p.tag)+"_lab"+std::to_string(lab)+"_src"+std::to_string(ie)).c_str(),
+                                 (";"+std::string(p.pretty)+"-plane semantic COUNT;Events").c_str(),
+                                 nbins, xmin, xmax),
+            col, "w_nominal");
+
         const TH1D& part = rr.GetValue();
         if (!H[lab]) {
           H[lab].reset(static_cast<TH1D*>(part.Clone(("h_"+std::string(p.tag)+"_lab"+std::to_string(lab)).c_str())));
           H[lab]->SetDirectory(nullptr);
-        } else H[lab]->Add(&part);
+        } else {
+          H[lab]->Add(&part);
+        }
       }
     }
 
+    // Style & (optional) PDF normalisation
     double ymax = 0.0;
     for (int lab = 0; lab < nlabels; ++lab) {
       if (!H[lab]) continue;
       if (normalize_to_pdf) normalize_pdf(*H[lab]);
+      H[lab]->SetStats(false);
       H[lab]->SetFillStyle(0);
       H[lab]->SetLineColor(color_for_label(lab));
       H[lab]->SetLineWidth(3);
@@ -114,25 +167,37 @@ void plot_semantic_count_shapes_perplane(const char* extra_libs = "",
 
     const std::string cname = std::string("c_cnt_") + p.tag;
     TCanvas c(cname.c_str(), cname.c_str(), 900, 700);
-    TH1D* frame = nullptr; for (int lab = 0; lab < nlabels; ++lab) if (H[lab]) { frame = H[lab].get(); break; }
-    if (!frame) continue;
-    frame->SetTitle((std::string(";") + (char)toupper(*p.tag) + "-plane semantic COUNT; " + (normalize_to_pdf ? "Probability density" : "Events")).c_str());
-    frame->SetMaximum(1.3*ymax); frame->SetMinimum(0.0);
-    frame->Draw("HIST");
-    for (int lab = 0; lab < nlabels; ++lab) if (H[lab].get() != frame) H[lab]->Draw("HIST SAME");
 
-    TLegend leg(0.60, 0.66, 0.88, 0.88);
+    TH1D* frame = nullptr;
+    for (int lab = 0; lab < nlabels; ++lab) if (H[lab]) { frame = H[lab].get(); break; }
+    if (!frame) continue;
+
+    // No plot title — only axis titles. Also: no exponents on axes.
+    frame->SetTitle((";"+std::string(p.pretty)+"-plane semantic COUNT;"+std::string(normalize_to_pdf ? "Probability density" : "Events")).c_str());
+    frame->GetXaxis()->SetNoExponent(true);
+    frame->GetYaxis()->SetNoExponent(true);
+    frame->GetXaxis()->SetMaxDigits(4);
+    frame->GetYaxis()->SetMaxDigits(4);
+
+    frame->SetMaximum( (ymax>0 ? 1.25*ymax : 1.) );
+    frame->SetMinimum(0.0);
+    frame->Draw("HIST");
+
+    for (int lab = 0; lab < nlabels; ++lab)
+      if (H[lab].get() != frame) H[lab]->Draw("HIST SAME");
+
+    // Legend with proper semantic names
+    TLegend leg(0.55, 0.65, 0.88, 0.88);
     leg.SetBorderSize(0); leg.SetFillStyle(0); leg.SetTextFont(42);
-    for (int lab = 0; lab < nlabels; ++lab) if (H[lab]) leg.AddEntry(H[lab].get(), label_name(lab).c_str(), "l");
+    for (int lab = 0; lab < nlabels; ++lab) if (H[lab]) {
+      leg.AddEntry(H[lab].get(), label_name_from_map(lab, nlabels).c_str(), "l");
+    }
     leg.Draw();
 
-    TLatex tl; tl.SetNDC(); tl.SetTextFont(42); tl.SetTextSize(0.04);
-    tl.DrawLatex(0.14, 0.92, Form("#muBooNE Simulation – %s counts – Empty selection – %s",
-                                  use_event_counts ? "event" : "slice",
-                                  normalize_to_pdf ? "PDF" : "counts"));
+    // No TLatex banner/title here.
 
     c.SaveAs((out_dir + "/semantic_counts_" + p.tag + ".pdf").c_str());
   }
 
-  std::cout << "Saved all-label semantic COUNT PDFs (no channel split) in: " << out_dir << std::endl;
+  std::cout << "Saved all-label semantic COUNT plots (no channel split) in: " << out_dir << std::endl;
 }

--- a/src/plot/UnstackedHist.cc
+++ b/src/plot/UnstackedHist.cc
@@ -187,18 +187,21 @@ void UnstackedHist::draw_curves(TPad* p_main, double& max_y) {
   TH1D* frame = mc_ch_hists_.front().get();
 
   if (spec_.xmin < spec_.xmax) frame->GetXaxis()->SetLimits(spec_.xmin, spec_.xmax);
-  frame->SetTitle((spec_.title.empty() ? (";"+opt_.x_title+";"+opt_.y_title) : spec_.title).c_str());
-  if (!opt_.x_title.empty()) frame->GetXaxis()->SetTitle(opt_.x_title.c_str());
-  if (!opt_.y_title.empty()) frame->GetYaxis()->SetTitle(opt_.y_title.c_str());
-  if (normalize_to_pdf_)      frame->GetYaxis()->SetTitle("Probability density");
+
+  // Title: only axis titles, no main title.
+  frame->SetTitle((std::string(";") + opt_.x_title + ";" + (normalize_to_pdf_ ? "Probability density" : opt_.y_title)).c_str());
+
+  // NEW: readable numeric scale (no ×10^n)
+  frame->GetXaxis()->SetNoExponent(true);
+  frame->GetYaxis()->SetNoExponent(true);
+  frame->GetXaxis()->SetMaxDigits(4);
+  frame->GetYaxis()->SetMaxDigits(4);
 
   frame->SetMaximum(max_y * (opt_.use_log_y ? 10. : 1.3));
   frame->SetMinimum(opt_.use_log_y ? 0.1 : opt_.y_min);
 
   frame->Draw("HIST");
-  for (size_t i = 1; i < mc_ch_hists_.size(); ++i) {
-    mc_ch_hists_[i]->Draw("HIST SAME");
-  }
+  for (size_t i = 1; i < mc_ch_hists_.size(); ++i) mc_ch_hists_[i]->Draw("HIST SAME");
   if (data_hist_) data_hist_->Draw("E1 SAME");
 }
 


### PR DESCRIPTION
## Summary
- refresh the semantic count macro with named labels, consistent styling, and PDF normalisation controls
- ensure unstacked histogram frames drop the main title and suppress scientific notation on axes
- update the global plot style to disable ROOT titles and cap axis digit counts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4da39b9c8832e97f7251beb05c4a9