### PR TITLE
Fix TH1DModel construction with custom bin edges

### DIFF
--- a/macros/plot_semantic_count_shapes_perplane.C
+++ b/macros/plot_semantic_count_shapes_perplane.C
@@ -158,7 +158,8 @@ void plot_semantic_count_shapes_perplane(const char* extra_libs = "",
         ROOT::RDF::TH1DModel model(
             ("h_"+std::string(p.tag)+"_lab"+std::to_string(lab)+"_src"+std::to_string(ie)).c_str(),
             (";"+std::string(p.pretty)+"-plane semantic COUNT;Events").c_str(),
-            log_edges);
+            static_cast<int>(log_edges.size() - 1),
+            log_edges.data());
         auto rr = n1.Histo1D(model, col, "w_nominal");
 
         const TH1D& part = rr.GetValue();


### PR DESCRIPTION
## Summary
- correct the TH1DModel initialization to pass the number of bins and the bin edge array when using custom log-spaced edges

## Testing
- `./rarexsec-root.sh -c macros/plot_semantic_count_shapes_perplane.C` *(fails in container: root command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4fd78f09c832eb136ed0b6daa1235