### PR TITLE
Fix Selection include path in active pixels macro

### DIFF
--- a/macros/plot_active_pixels_by_channel.C
+++ b/macros/plot_active_pixels_by_channel.C
@@ -11,7 +11,7 @@
 #include <iostream>
 
 #include <rarexsec/Hub.hh>
-#include <rarexsec/Selection.hh>
+#include <rarexsec/proc/Selection.hh>
 #include <rarexsec/Plotter.hh>               // H1Spec, Options
 #include <rarexsec/plot/UnstackedHist.hh>    // overlay-by-channel plotter
 


### PR DESCRIPTION
## Summary
- update the active pixels plotting macro to include the Selection header from its current location

## Testing
- ./rarexsec-root.sh -c macros/plot_active_pixels_by_channel.C *(fails: root command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e500528fb8832ead5e437e4b6d046e