### PR TITLE
Handle RVec inputs in active pixel plotting macro

### DIFF
--- a/macros/plot_active_pixels_by_channel.C
+++ b/macros/plot_active_pixels_by_channel.C
@@ -1,6 +1,7 @@
 // plot_active_pixels_by_channel.C
 #include <ROOT/RDataFrame.hxx>
 #include <ROOT/RDFHelpers.hxx>
+#include <ROOT/RVec.hxx>
 #include <TSystem.h>
 #include <TH1D.h>
 
@@ -33,6 +34,13 @@ static void load_libs(const char* extra_libs) {
 
 // Return the ABSOLUTE COUNT of active pixels (> thr) in a single image (vector<float>)
 double active_pixels(const std::vector<float>& img, double thr) {
+  if (img.empty()) return 0.0;
+  std::size_t k = 0; for (float q : img) if (std::isfinite(q) && q > thr) ++k;
+  return static_cast<double>(k);
+}
+
+// Overload for RDF columns backed by RVec<float>
+double active_pixels(const ROOT::VecOps::RVec<float>& img, double thr) {
   if (img.empty()) return 0.0;
   std::size_t k = 0; for (float q : img) if (std::isfinite(q) && q > thr) ++k;
   return static_cast<double>(k);


### PR DESCRIPTION
## Summary
- include ROOT RVec header in the active pixel plotting macro
- add an active_pixels overload that accepts ROOT::VecOps::RVec<float> inputs so RDF expressions compile

## Testing
- ./rarexsec-root.sh -c macros/plot_active_pixels_by_channel.C *(fails: root command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5012df2d4832eaf1372783ba3c617