### PR TITLE
Handle RVec inputs in active pixel helper

### DIFF
--- a/macros/plot_active_pixels_by_channel.C
+++ b/macros/plot_active_pixels_by_channel.C
@@ -9,6 +9,7 @@
 #include <vector>
 #include <sstream>
 #include <iostream>
+#include <cmath>
 
 #include <rarexsec/Hub.hh>
 #include <rarexsec/proc/Selection.hh>
@@ -31,8 +32,9 @@ static void load_libs(const char* extra_libs) {
   }
 }
 
-// Return the ABSOLUTE COUNT of active pixels (> thr) in a single image (vector<float>)
-double active_pixels(const std::vector<float>& img, double thr) {
+// Return the ABSOLUTE COUNT of active pixels (> thr) in a single image container
+template <typename Image>
+double active_pixels(const Image& img, double thr) {
   if (img.empty()) return 0.0;
   std::size_t k = 0; for (float q : img) if (std::isfinite(q) && q > thr) ++k;
   return static_cast<double>(k);


### PR DESCRIPTION
## Summary
- allow the active_pixels helper in the plotting macro to operate on generic image containers so RDF RVec columns compile
- include <cmath> for access to std::isfinite

## Testing
- ./rarexsec-root.sh -c macros/plot_active_pixels_by_channel.C *(fails: root not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5016a95f4832ea060b428e7c0c1e3